### PR TITLE
Add required props to published docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -612,4 +612,13 @@ publishing {
 	}
 }
 
+artifactoryPublish {
+	publications(publishing.publications.mavenJava)
+	properties {
+		mavenJava '*:*:*:*@zip', 'zip.name': 'spring-pulsar', 'zip.displayname': 'Spring Pulsar', 'zip.deployed': false
+		mavenJava '*:*:*:docs@zip', 'zip.type': 'docs'
+		mavenJava '*:*:*:dist@zip', 'zip.type': 'dist'
+	}
+}
+
 apply from: "${rootDir}/gradle/docs.gradle"


### PR DESCRIPTION
The `zip.deployed=false, zip.type=docs` needs to be set in order for the docs to get auto-deployed to static.spring.io