### PR TITLE
Add basic docs

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -1,0 +1,44 @@
+= Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of fostering an open
+and welcoming community, we pledge to respect all people who contribute through reporting
+issues, posting feature requests, updating documentation, submitting pull requests or
+patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for
+everyone, regardless of level of experience, gender, gender identity and expression,
+sexual orientation, disability, personal appearance, body size, race, ethnicity, age,
+religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic addresses,
+  without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments,
+commits, code, wiki edits, issues, and other contributions that are not aligned to this
+Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors
+that they deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and
+consistently applying these principles to every aspect of managing this project. Project
+maintainers who do not follow or enforce the Code of Conduct may be permanently removed
+from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces when an
+individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
+contacting a project maintainer at spring-code-of-conduct@pivotal.io . All complaints will
+be reviewed and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances. Maintainers are obligated to maintain confidentiality
+with regard to the reporter of an incident.
+
+This Code of Conduct is adapted from the
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,60 @@
+= Contributing to Spring Pulsar
+
+Spring Pulsar is released under the Apache 2.0 license. If you would like to contribute something, or want to hack on the code this document should help you get started.
+
+
+
+== Code of Conduct
+This project adheres to the Contributor Covenant link:CODE_OF_CONDUCT.adoc[code of conduct].
+By participating, you are expected to uphold this code. Please report unacceptable behavior to spring-code-of-conduct@pivotal.io.
+
+
+
+== Using GitHub Issues
+We use GitHub issues to track bugs and enhancements.
+// NYI
+// If you have a general usage question please ask on https://stackoverflow.com[Stack Overflow].
+// The Spring Pulsar team and the broader community monitor the https://stackoverflow.com/tags/spring-pulsar[`spring-pulsar`] tag.
+
+If you are reporting a bug, please help to speed up problem diagnosis by providing as much information as possible.
+Ideally, that would include a small sample project that reproduces the problem.
+
+
+
+== Reporting Security Vulnerabilities
+If you think you have found a security vulnerability in Spring Pulsar please *DO NOT* disclose it publicly until we've had a chance to fix it.
+Please don't report security vulnerabilities using GitHub issues, instead head over to https://spring.io/security-policy and learn how to disclose them responsibly.
+
+
+
+== Sign the Contributor License Agreement
+Before we accept a non-trivial patch or pull request we will need you to https://cla.pivotal.io/sign/spring[sign the Contributor License Agreement].
+Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do.
+Active contributors might be asked to join the core team, and given the ability to merge pull requests.
+
+
+
+== Code Conventions and Housekeeping
+None of these is essential for a pull request, but they will all help.  They can also be
+added after the original pull request but before a merge.
+
+* We use the https://github.com/spring-io/spring-javaformat/[Spring JavaFormat] project to apply code formatting conventions.
+  If you use Eclipse and you follow the '`Importing into eclipse`' instructions below you should get project specific formatting automatically.
+  You can also install the https://github.com/spring-io/spring-javaformat/#intellij-idea[Spring JavaFormat IntelliJ Plugin] or format the code from the Gradle build by running `./gradlew format`.
+// NYI: Note that if you have format violations in `buildSrc`, you can fix them by running `./gradlew -p buildSrc format` from the project root directory.
+* The build includes Checkstyle rules for many of our code conventions. Run `./gradlew checkstyleMain checkstyleTest` if you want to check your changes are compliant.
+* Make sure all new `.java` files have a Javadoc class comment with at least an `@author` tag identifying you, and preferably at least a paragraph on what the class is for.
+* Add the ASF license header comment to all new `.java` files (copy from existing files in the project).
+* Add yourself as an `@author` to the `.java` files that you modify substantially (more than cosmetic changes).
+* Add some Javadocs.
+* A few unit tests would help a lot as well -- someone has to do it.
+* Verification tasks, including tests and Checkstyle, can be executed by running `./gradlew check` from the project root.
+  Note that `SPRING_PROFILES_ACTIVE` environment variable might affect the result of tests, so in that case, you can prevent it by running `unset SPRING_PROFILES_ACTIVE` before running the task.
+* If no-one else is using your branch, please rebase it against the current main branch (or other target branch in the project).
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions].
+
+
+
+== Working with the Code
+**#TODO#**
+For information on editing, building, and testing the code, see the https://github.com/spring-projects/spring-pulsar/wiki/Working-with-the-Code[Working with the Code] page on the project wiki.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.adoc
+++ b/README.adoc
@@ -1,405 +1,78 @@
-# Spring for Apache Pulsar
+= Spring for Apache Pulsar
+:docs: https://docs.spring.io/spring-pulsar/docs/current-SNAPSHOT/reference
+:github: https://github.com/spring-projects-experimental/spring-pulsar
 
-This project provides a basic Spring friendly API for developing https://pulsar.apache.org/[Apache Pulsar] applications.
+Spring Pulsar provides a basic Spring-friendly API for developing https://pulsar.apache.org/[Apache Pulsar] applications.
 
-Most of the ideas in this project are borrowed from the Spring for Apache Kafka project, thus a familiarity with the Spring support available in Spring for Apache Kafka would help a lot.
+**#WARNING#**: This is a WIP project. Many of the support available at the moment are prototypes and experimental.
 
-** #IMPORTANT#: This is a WIP project. Many of the support available at the moment are prototypes and experimental.
+**#TIP#**: Most of the ideas in this project are borrowed from the Spring for Apache Kafka project, thus a familiarity with it would help.
 
-### Building the project
-
-#### Minimum Supported Versions
-
-**JDK** - JDK 17
-
-**Apache Pulsar** - 2.10.0
-
-**Spring Boot** - 3.0.0
-
-**Spring Framework** - 6.0.0
-
-```
-./gradlew clean build
-```
-
-The build will produce two artifacts -- `spring-pulsar` and `spring-pulsar-spring-boot-autoconfigure`
-
-### Spring Boot Auto Configuration
-
-We recommend using the library `spring-pulsar` in association with Spring Boot and therefore should also use `spring-pulsar-spring-boot-autoconfigure`.
-If you simply use the module `spring-pulsar-spring-boot-autoconfigure`, then that will transitively include `spring-pulsar`.
-
-#### Pulsar Client
-
-When using `spring-pulsar-spring-boot-autoconfigure`, you get the `PulsarClient` auto-configured.
-This is done through a factory bean called `PulsarClientFactoryBean`, which takes a configuration object `PulsarClientConfiguration`.
-By default, the application tries to connect a local Pulsar instance available at `pulsar://localhost:6650`.
-
-The properties listed below are available to be set on the Pulsar client.
-
-The same defaults expected by the Pulsar client are honored when no configuration provided for these properties.
-
-```
-spring.pulsar.client.serviceUrl
-spring.pulsar.client.authPluginClassName
-spring.pulsar.client.authParams
-spring.pulsar.client.operationTimeoutMs
-spring.pulsar.client.statsIntervalSeconds
-spring.pulsar.client.numIoThreads
-spring.pulsar.client.useTcpNoDelayuseTls
-spring.pulsar.client.tlsAllowInsecureConnection
-spring.pulsar.client.tlsHostnameVerificationEnable
-spring.pulsar.client.concurrentLookupRequest
-spring.pulsar.client.maxLookupRequest
-spring.pulsar.client.maxNumberOfRejectedRequestPerConnection
-spring.pulsar.client.keepAliveIntervalSeconds
-spring.pulsar.client.connectionTimeoutMs
-spring.pulsar.client.requestTimeoutMs
-spring.pulsar.client.initialBackoffIntervalNanos
-spring.pulsar.client.maxBackoffIntervalNanos;
-```
-
-#### Pulsar Producer
-
-On the Pulsar producer side, Sprig Boot auto-configuration will provide a `PulsarTemplate` which is backed by a `PulsarProducerFactory`.
-We will see more details of these components later in this document, but in this section, let us look at the configuration properties available on the producer.
-
-These properties must be prefixed with `spring.pulsar.producer`.
-
-The same defaults expected by the Pulsar producer are honored when no configuration provided for these properties.
-
-```
-spring.pulsar.producer.topicName
-spring.pulsar.producer.producerName
-spring.pulsar.producer.sendTimeoutMs
-spring.pulsar.producer.blockIfQueueFull
-spring.pulsar.producer.maxPendingMessages
-spring.pulsar.producer.maxPendingMessagesAcrossPartitions
-spring.pulsar.producer.messageRoutingMode
-spring.pulsar.producer.hashingScheme
-spring.pulsar.producer.cryptoFailureAction
-spring.pulsar.producer.batchingMaxPublishDelayMicros
-spring.pulsar.producer.batchingMaxMessages
-spring.pulsar.producer.batchingEnabled
-spring.pulsar.producer.chunkingEnabled
-spring.pulsar.producer.compressionType
-spring.pulsar.producer.initialSubscriptionName
-spring.pulsar.producer.accessMode
-```
-
-#### Pulsar Consumer
-
-When it comes to Pulsar consumer, we recommend the end user applications to make use of the `PulsarListener` annotation.
-In order to use `PulsarListener`, you need to use the `EnablePulsar` annotation.
-When using the Spring Boot support, it automatically enables this annotation and configures all the components necessary for `PulsarListener` such as the message listener infrastructure which is responsible for creating the Pulsar consumer.
-`PulsarMessageListenerContainer` uses a `PulsarConsumerFactory` in order to create and manage the Pulsar consumer.
-This consumer factory is auto-configured through Spring Boot.
-Following are the consumer properties that you can configure through the Boot support.
-
-The same defaults expected by the Pulsar consumer are honored when no configuration provided for these properties.
-
-```
-spring.pulsar.consumer.topicNames
-spring.pulsar.consumer.topicsPattern
-spring.pulsar.consumer.subscriptionName
-spring.pulsar.consumer.subscriptionType
-spring.pulsar.consumer.receiverQueueSize
-spring.pulsar.consumer.acknowledgementsGroupTimeMicros
-spring.pulsar.consumer.negativeAckRedeliveryDelayMicros
-spring.pulsar.consumer.maxTotalReceiverQueueSizeAcrossPartitions
-spring.pulsar.consumer.consumerName
-spring.pulsar.consumer.ackTimeoutMillis
-spring.pulsar.consumer.tickDurationMillis
-spring.pulsar.consumer.priorityLevel
-spring.pulsar.consumer.cryptoFailureAction
-spring.pulsar.consumer.properties
-spring.pulsar.consumer.readCompacted
-spring.pulsar.consumer.subscriptionInitialPosition
-spring.pulsar.consumer.patternAutoDiscoveryPeriod
-spring.pulsar.consumer.regexSubscriptionMode
-spring.pulsar.consumer.autoUpdatePartitions
-spring.pulsar.consumer.replicateSubscriptionState
-spring.pulsar.consumer.autoAckOldestChunkedMessageOnQueueFull
-spring.pulsar.consumer.maxPendingChunkedMessageexpireTimeOfIncompleteChunkedMessageMillis
-```
-
-### Sample Applications
-
-In this section, we will show a number of various applications to demonstrate how you can use the Spring for Apache Pulsar library using Spring Boot.
-
-Here are the maven coordinates of the artifacts needed for using this library.
-
-```
-<dependency>
-    <groupId>org.springframework.pulsar</groupId>
-    <artifactId>spring-pulsar</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
-</dependency>
-
-<dependency>
-    <groupId>org.springframework.pulsar</groupId>
-    <artifactId>spring-pulsar-boot-autoconfiguration</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
-</dependency>
-```
-
-If you simply include the `spring-pulsar-boot-autoconfiguration` module, then that will transitively include the `spring-pulsar` module.
-
-#### Quick Primer on Publishing to and Consuming from an Apache Pulsar Topic
-
-In order to publish to a Pulsar topic, the easiest way is to use the `PulsarTemplate` API.
-Similarly, the easiest way to consume from a Pulsar topic is to use the `PulsarListener` annotation.
-
-The following is a complete Spring Boot application that publishes to a Pulsar topic called `hello-pulsar` and then consumes from it.
-
-```
-@SpringBootApplication
-public class PulsarBootHelloWorld {
-
-	public static void main(String[] args) {
-		SpringApplication.run(PulsarBootHelloWorld.class, args);
-	}
-
-	@Bean
-	public ApplicationRunner runner(PulsarTemplate<String> pulsarTemplate) {
-		pulsarTemplate.setDefaultTopicName("hello-pulsar");
-		return args -> {
-			for (int i = 0; i < 10; i ++) {
-				pulsarTemplate.send("This is message " + (i + 1));
-			}
-
-		};
-	}
-
-	@PulsarListener(subscriptionName = "hello-pulsar-subscription", topics = "hello-pulsar")
-	public void listen(String message) {
-		System.out.println("Message Received: " + message);
-	}
-}
-```
-
-Although this is a very trivial application, it conveys several important concepts nonetheless. Let's take a look at them.
-
-`PulsarTemplate` is autoconfigured by Spring Boot, and we are injecting that in the application.
-There is a producer factory behind the scenes and properties can be provided to it using `spring.pulsar.producer...` (See above for more details).
-When injecting, note that, we can provide a specific type - `String` in this case.
-If we have a need for a different `PulsarTemplate` with a different type in the same application, then we can add another injection with that type.
-`PulsarTemplate` currently requires the application to set a default topic.
-Once the topic is set, then we can call the various `send` methods on it.
-In this example, we are calling the very basic synchronous `send` method that is internally forwarded to the Pulsar producer that returns the `MessageId`.
-We are ignoring the return value in this quick sample application.
-`PulsarTemplate` also provides APIs for sending asynchronously among other send methods.
-We will look at the details of it, later on in the reference documentation.
-
-We use the `PulsarListener` annotation to consume from the topic.
-We are providing the subscription and topic names as annotation arguments.
-These are optional and the application may prefer to set them using the `spring.pulsar.consumer..` properties provided above.
-There are four consumer level properties that you can set on the `PulsarListener` annotation - they are `topics`, `topicPattern`, `subscriptionName` and `subscriptionType`.
-When provided on the annotation, they get preference regardless of what is set through consumer properties.
-
-By default, `PulsarListener` uses an exclusive subscription type and this can be changed by using the `subscriptionType` property on the annotation or through the consumer property.
-
-`PulsarListener` internally creates a message listener container.
-The message listener container is responsible for creating the Pulsar Consumer using a consumer factory.
-When the consumer receives data, the container calls a message listener.
-This message listener is an adapter around the user provided method - the `listen` method in this case.
-The message listener container delegates to the adapter with the received data and the adapter then invokes the user method.
-
-In order to complete the discussion about this sample application, we also need to chime in on how data conversion is done.
-In the user method, we receive the data as `String`, but we don't specify any schema types.
-Internally, the framework by default relies on Pulsar's schema mechanism to convert the data to the required type.
-The framework detects that you are expecting the `String` type and then infer the schema type based on that information.
-Then it provides that schema to the consumer.
-For all the primitive types in Java, the framework does this inference.
-For any complex types, such as JSON, AVRO etc. the framework cannot do this inference and the user needs to provide the schema type on the annotation using the `schemaType` property.
-
-In the example above, and in the ones that follows below, we provide both producer and consumer as part of the same application.
-However, in real apps, you might find it as convenient to separate them especially if you are following a microservice style architecture.
-
-#### Partitioned topics - Publishing and Consuming.
-
-In the sample below, we are publishing to a topic called `hello-pulsar-partitioned`.
-It is a topic that is partitioned and for this sample we assume that the topic is already created with three partitions.
-
-```
-@SpringBootApplication
-public class PulsarBootPartitioned {
-
-	public static void main(String[] args) {
-		SpringApplication.run(PulsarBootPartitioned.class, "--spring.pulsar.producer.messageRoutingMode=CustomPartition");
-	}
-
-	@Bean
-	public ApplicationRunner runner(PulsarTemplate<String> pulsarTemplate) {
-		pulsarTemplate.setDefaultTopicName("hello-pulsar-partitioned");
-		return args -> {
-			for (int i = 0; i < 10; i++) {
-				pulsarTemplate.sendAsync("hello john doe 0 ", new FooRouter());
-				pulsarTemplate.sendAsync("hello alice doe 1", new BarRouter());
-				pulsarTemplate.sendAsync("hello buzz doe 2", new BuzzRouter());
-			}
-		};
-	}
-
-	@PulsarListener(subscriptionName = "hello-pulsar-partitioned-subscription", topics = "hello-pulsar-partitioned")
-	public void listen(String message) {
-		System.out.println("Message Received: " + message);
-	}
-
-    static class FooRouter implements MessageRouter {
-
-		@Override
-		public int choosePartition(Message<?> msg, TopicMetadata metadata) {
-			return 0;
-		}
-	}
-
-	static class BarRouter implements MessageRouter {
-
-		@Override
-		public int choosePartition(Message<?> msg, TopicMetadata metadata) {
-			return 1;
-		}
-	}
-
-	static class BuzzRouter implements MessageRouter {
-
-		@Override
-		public int choosePartition(Message<?> msg, TopicMetadata metadata) {
-			return 2;
-		}
-	}
-
-}
-```
-
-A few things require explanation in the application above.
-We are publishing to a partitioned topic and we would like to publish some data segment to a specific partition.
-If you leave it to Pulsar's default, it follows a round-robin mode of partition assignments, and we would like to override that.
-In order to do that, we are providing a message router object with the send method.
-Look at the three message routers implemented.
-`FooRouter` always sends data to partition `0`, `BarRouter` to partition `1` and `BuzzRouter` to partition `2`.
-Also note that, we are now using the `sendAsync` method of `PulsarTemplate` that returns a `CompletableFuture`.
-When running the application, we also need to set the `messageRoutingMode` on the producer to `CustomPartition` (`spring.pulsar.producer.messageRoutingMode`).
-
-On the consumer side, we are using a `PulsarListener` with the exclusive subscription type.
-This means that data from all the partitions will end up in the same consumer and there is no ordering guarantee.
-
-What can we do if we want each partition to be consumed by a single distinct consumer?
-We can switch to the `failover` subscription mode and add three separate consumers.
-
-Here is an example.
-
-```
-@PulsarListener(subscriptionName = "hello-pulsar-partitioned-subscription", topics = "hello-pulsar-partitioned", subscriptionType = "failover")
-public void listen1(String foo) {
-    System.out.println("Message Received 1: " + foo);
-}
-
-@PulsarListener(subscriptionName = "hello-pulsar-partitioned-subscription", topics = "hello-pulsar-partitioned", subscriptionType = "failover")
-public void listen2(String foo) {
-    System.out.println("Message Received 2: " + foo);
-}
-
-@PulsarListener(subscriptionName = "hello-pulsar-partitioned-subscription",  topics = "hello-pulsar-partitioned", subscriptionType = "failover")
-public void liste3n(String foo) {
-    System.out.println("Message Received 3: " + foo);
-}
-```
-
-When following this approach, you can see that a single partition always gets consumed by a dedicated consumer.
-
-In the similar vein, if you want to use Pulsar's shared consumer type, you can use the subscription type `shared`.
-Keep in mind though, that when using the `shared` mode, you lose any ordering guarantees as a single consumer may receive messages from all the partitions before another consumer gets a chance.
-
-Here is an example.
-
-```
-@PulsarListener(subscriptionName = "hello-pulsar-shared-subscription", topics = "hello-pulsar-partitioned", subscriptionType = "shared")
-public void listen1(String foo) {
-    System.out.println("Message Received 1: " + foo);
-}
-
-@PulsarListener(subscriptionName = "hello-pulsar-shared-subscription", topics = "hello-pulsar-partitioned", subscriptionType = "shared")
-public void listen2(String foo) {
-    System.out.println("Message Received 2: " + foo);
-}
-```
-
-#### Consuming Messages in Batch Mode
-
-In the examples above, we used `PulsarListener` in record mode, i.e. we receive a single message on each method invocation.
-Sometimes, for various reasons, we may want to receive Pulsar messages in batch mode. Here is a `PulsarListener` that is enabled with batch consumption.
-
-```
-@PulsarListener(subscriptionName = "batch-subscription", topics = "hello-pulsar", batch = "true")
-public void listen(List<String> records) {
-    System.out.println("Message Received from batch: " + records);
-}
-```
-
-In order to enable batch consumption, you need to set the `batch` property to `true` on `PulsarListener`.
-Then you can receive the records as a `List` type.
-Based on the actual type that the `List` holds, the framework tries to infer the schema to use.
-If the `List` contains a complex type, then the `schemaType` still needs to be provided on `PulsarListener`.
-
-#### Accessing the Pulsar Message Object
-
-In your `PulsarListener` method, you can receive the record directly as a Pulsar Message instead of the actual payload type.
-Here is an example.
-
-```
-@PulsarListener(subscriptionName = "hello-pulsar-subscription", topics = "hello-pulsar")
-public void listen(org.apache.pulsar.client.api.Message<String> message) {
-    System.out.println("Data Received: " + message.getValue());
-}
-```
-
-#### Accessing the Pulsar Messages Object
-
-When consuming messages in batch mode using `PulsarListener`, instead of receiving them as a `List`, you can receive them as Pulsar Messages type.
-Here is an example.
-
-```
-@PulsarListener(subscriptionName = "batch-subscription", topics = "hello-pulsar", batch = "true")
-public void listen(org.apache.pulsar.client.api.Messages<String> messages) {
-    // Iterate on the messages
-    // Each iteration gives access to a org.apache.pulsar.client.api.Message object
-}
-```
-
-#### Accessing the Pulsar Consumer Object
-
-Sometimes, it is necessary to gain direct access to the Pulsar Consumer object.
-Here is how you may do so.
-
-```
-@PulsarListener(subscriptionName = "hello-pulsar-subscription", topics = "hello-pulsar")
-public void listen(String message, org.apache.pulsar.client.api.Consumer<String> consumer) {
-    System.out.println("Message Received: " + message);
-    ConsumerStats stats = consumer.getStats();
-    ...
-}
-```
-
-When accessing the `Consumer` object this way, make sure NOT to invoke any operations that would change the Consumer's cursor position by invoking any receive methods.
-All such operations must be done by the container.
-
-#### Specify schema information
-
-As indicated above, for normal Java types (the primitive ones), Spring Pulsar framework can infer the proper Schema to use on the `PulsarListener`.
-However, for more complex types such as JSON or AVRO, you need to specify the schema type on the annotation.
-Here is how you provide that.
-
-```
-@PulsarListener(subscriptionName = "json-subscription", topics = "hello-pulsar-json", schemaType = SchemaType.JSON)
-public void listen(Foo foo) {
-    System.out.println("Message received: " + foo);
-}
-```
-
-On the producer side also, for the Java primitive types, the framework can infer the Schema, but for any other types, you need set that on the `PulsarTemmplate`.
-
-#### PulsarTemplate API details
-
-### More support to come -- stay tuned...
+== Getting Started
+The {docs}/html/[reference documentation] includes a {docs}/html/#quick-tourhtml[quick tour] section.
+
+== Getting Help
+Are you having trouble with Spring Pulsar? We want to help!
+
+* Check the {docs}/html/[reference documentation]
+* Learn the Spring basics -- Spring Pulsar builds on many other Spring projects; check the https://spring.io[spring.io] website for a wealth of reference documentation.
+If you are new to Spring, try one of the https://spring.io/guides[guides].
+// TODO (NYI): * If you are upgrading, read the {github}/wiki[release notes] for upgrade instructions and "new and noteworthy" features.
+// TODO (NYI): * Ask a question -- we monitor https://stackoverflow.com[stackoverflow.com] for questions tagged with https://stackoverflow.com/tags/spring-pulsar[`spring-pulsar`].
+* Report bugs with Spring Pulsar at {github}/issues[github.com/spring-projects-experimental/spring-pulsar/issues].
+
+
+
+== Reporting Issues
+Spring Pulsar uses GitHub's integrated issue tracking system to record bugs and feature requests.
+If you want to raise an issue, please follow the recommendations below:
+
+* Before you log a bug, please search the {github}/issues[issue tracker] to see if someone has already reported the problem.
+* If the issue doesn't already exist, {github}/issues/new[create a new issue].
+* Please provide as much information as possible with the issue report.
+We like to know the Spring Pulsar version, operating system, and JVM version you're using.
+* If you need to paste code or include a stack trace, use Markdown +++```+++ escapes before and after your text.
+* If possible, try to create a test case or project that replicates the problem and attach it to the issue.
+
+
+
+== Building from Source
+You don't need to build from source to use Spring Pulsar (binaries in https://repo.spring.io[repo.spring.io]), but if you want to try out the latest and greatest, Spring Pulsar can be built and published to your local Maven cache using the https://docs.gradle.org/current/userguide/gradle_wrapper.html[Gradle wrapper].
+You also need JDK 17.
+
+[indent=0]
+----
+	$ ./gradlew publishToMavenLocal
+----
+
+This will build all of the jars and documentation and publish them to your local Maven cache.
+It won't run any of the tests.
+If you want to build everything, use the `build` task:
+
+[indent=0]
+----
+	$ ./gradlew build
+----
+
+
+
+== Modules
+There are several modules in Spring Pulsar. Here is a quick overview:
+
+=== spring-pulsar
+The main library that provides the API to access Apache Pulsar.
+
+=== spring-pulsar-dependencies
+Provides a Gradle https://docs.gradle.org/current/userguide/java_platform_plugin.html[java-platform] that recommends dependency versions.
+
+=== spring-pulsar-docs
+Provides reference docs and handles aggregating javadocs.
+
+=== spring-pulsar-spring-boot-autoconfigure
+Provides Spring Boot auto-configuration for Spring Pulsar.
+
+=== spring-pulsar-sample-apps
+Provides sample applications to illustrate Spring Pulsar functionality as well as provide ability for quick manual verification during development.
+
+== License
+Spring Pulsar is Open Source software released under the https://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].


### PR DESCRIPTION
Removes the redundant details from README that are now in the ref docs. Also adds basic contributing, code of conduct, etc..