### PR TITLE
Add ProducerInterceptors to PulsarTemplate and PulsarProducerFactory

### DIFF
--- a/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
@@ -142,8 +142,6 @@ You can disable the autoconfigured producer factory by providing your own bean d
 Producer<T> createProducer(String topic, Schema<T> schema) throws PulsarClientException;
 
 Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter) throws PulsarClientException;
-
-Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter, List<ProducerInterceptor> producerInterceptors) throws PulsarClientException;
 ----
 ====
 

--- a/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
@@ -531,9 +531,9 @@ public void listen(Foo foo) {
 
 On the producer side also, for the Java primitive types, the framework can infer the Schema, but for any other types, you need set that on the `PulsarTemmplate`.
 
-=== Intercepting messages
+==== Intercepting messages
 
-==== Intercept messages on the Producer
+===== Intercept messages on the Producer
 Adding a `ProducerInterceptor`  allows you to intercept and mutate messages received by the producer before being published to the brokers.
 To do so, you can pass a list of interceptors into the `PulsarTemplate` constructor.
 When using multiple interceptors, the order they are applied in will be the order they appear in the list.
@@ -557,7 +557,7 @@ ProducerInterceptor secondInterceptor() {
 ```
 
 
-=== Appendix
+==== Appendix
 The reference documentation has the following appendices:
 
 [horizontal]

--- a/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
@@ -142,6 +142,8 @@ You can disable the autoconfigured producer factory by providing your own bean d
 Producer<T> createProducer(String topic, Schema<T> schema) throws PulsarClientException;
 
 Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter) throws PulsarClientException;
+
+Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter, List<ProducerInterceptor> producerInterceptors) throws PulsarClientException;
 ----
 ====
 
@@ -616,6 +618,32 @@ public void listen(Foo foo) {
 ```
 
 On the producer side also, for the Java primitive types, the framework can infer the Schema, but for any other types, you need set that on the `PulsarTemmplate`.
+
+=== Intercepting messages
+
+==== Intercept messages on the Producer
+Adding a `ProducerInterceptor`  allows you to intercept and mutate messages received by the producer before being published to the brokers.
+To do so, you can pass a list of interceptors into the `PulsarTemplate` constructor.
+When using multiple interceptors, the order they are applied in will be the order they appear in the list.
+
+If you are using Spring Boot auto-configuration, you can simply specify the interceptors as Beans.
+They will be passed automatically to the `PulsarTemplate`.
+Ordering of the interceptors is achieved by using the `@Order` annotation as seen below.
+
+```
+@Bean
+@Order(100)
+ProducerInterceptor firstInterceptor() {
+  ...
+}
+
+@Bean
+@Order(200)
+ProducerInterceptor secondInterceptor() {
+  ...
+}
+```
+
 
 === Appendix
 The reference documentation has the following appendices:

--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
@@ -17,8 +17,8 @@
 package org.springframework.pulsar.autoconfigure;
 
 import org.apache.pulsar.client.api.PulsarClient;
-
 import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
+
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -86,7 +86,8 @@ public class PulsarAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(PulsarTemplate.class)
-	public PulsarTemplate<?> pulsarTemplate(PulsarProducerFactory<?> pulsarProducerFactory, ObjectProvider<ProducerInterceptor> interceptors) {
+	public PulsarTemplate<?> pulsarTemplate(PulsarProducerFactory<?> pulsarProducerFactory,
+			ObjectProvider<ProducerInterceptor> interceptors) {
 		return new PulsarTemplate<>(pulsarProducerFactory, interceptors.orderedStream().toList());
 	}
 

--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
@@ -18,6 +18,8 @@ package org.springframework.pulsar.autoconfigure;
 
 import org.apache.pulsar.client.api.PulsarClient;
 
+import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -84,8 +86,8 @@ public class PulsarAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean(PulsarTemplate.class)
-	public PulsarTemplate<?> pulsarTemplate(PulsarProducerFactory<?> pulsarProducerFactory) {
-		return new PulsarTemplate<>(pulsarProducerFactory);
+	public PulsarTemplate<?> pulsarTemplate(PulsarProducerFactory<?> pulsarProducerFactory, ObjectProvider<ProducerInterceptor> interceptors) {
+		return new PulsarTemplate<>(pulsarProducerFactory, interceptors.orderedStream().toList());
 	}
 
 	@Bean

--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
@@ -42,6 +42,7 @@ import org.springframework.pulsar.core.PulsarTemplate;
  *
  * @author Soby Chacko
  * @author Chris Bono
+ * @author Alexander Preuß
  */
 @AutoConfiguration
 @ConditionalOnClass(PulsarTemplate.class)

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfigurationTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfigurationTests.java
@@ -49,6 +49,7 @@ import org.springframework.pulsar.listener.DefaultPulsarMessageListenerContainer
  * Autoconfiguration tests for {@link PulsarAutoConfiguration}.
  *
  * @author Chris Bono
+ * @author Alexander Preuß
  */
 @SuppressWarnings("unchecked")
 class PulsarAutoConfigurationTests {

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfigurationTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfigurationTests.java
@@ -17,10 +17,15 @@
 package org.springframework.pulsar.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.in;
 import static org.mockito.Mockito.mock;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -152,6 +157,17 @@ class PulsarAutoConfigurationTests {
 				.run((context) -> assertThat(context).hasNotFailed()
 						.getBean(PulsarListenerAnnotationBeanPostProcessor.class)
 						.isSameAs(listenerAnnotationBeanPostProcessor));
+	}
+
+	@Test
+	void customProducerInterceptorIsUsedInPulsarTemplate() {
+		ProducerInterceptor interceptor = mock(ProducerInterceptor.class);
+		this.contextRunner
+				.withBean("customProducerInterceptor", ProducerInterceptor.class, () -> interceptor)
+				.run((context -> assertThat(context).hasNotFailed()
+						.getBean(PulsarTemplate.class)
+						.extracting("interceptors").asInstanceOf(InstanceOfAssertFactories.list(ProducerInterceptor.class))
+						.contains(interceptor)));
 	}
 
 	@Nested

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfigurationTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfigurationTests.java
@@ -17,11 +17,8 @@
 package org.springframework.pulsar.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.in;
 import static org.mockito.Mockito.mock;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
@@ -162,11 +159,10 @@ class PulsarAutoConfigurationTests {
 	@Test
 	void customProducerInterceptorIsUsedInPulsarTemplate() {
 		ProducerInterceptor interceptor = mock(ProducerInterceptor.class);
-		this.contextRunner
-				.withBean("customProducerInterceptor", ProducerInterceptor.class, () -> interceptor)
-				.run((context -> assertThat(context).hasNotFailed()
-						.getBean(PulsarTemplate.class)
-						.extracting("interceptors").asInstanceOf(InstanceOfAssertFactories.list(ProducerInterceptor.class))
+		this.contextRunner.withBean("customProducerInterceptor", ProducerInterceptor.class, () -> interceptor)
+				.run((context -> assertThat(context).hasNotFailed().getBean(PulsarTemplate.class)
+						.extracting("interceptors")
+						.asInstanceOf(InstanceOfAssertFactories.list(ProducerInterceptor.class))
 						.contains(interceptor)));
 	}
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/CachingPulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/CachingPulsarProducerFactory.java
@@ -92,7 +92,8 @@ public class CachingPulsarProducerFactory<T> extends DefaultPulsarProducerFactor
 	}
 
 	@Override
-	public Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter, List<ProducerInterceptor> producerInterceptors) {
+	public Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter,
+			List<ProducerInterceptor> producerInterceptors) {
 		final String topicName = ProducerUtils.resolveTopicName(topic, this);
 		ProducerCacheKey<T> producerCacheKey = new ProducerCacheKey<>(schema, topicName, messageRouter);
 		return this.producerCache.get(producerCacheKey, (st) -> {
@@ -106,8 +107,8 @@ public class CachingPulsarProducerFactory<T> extends DefaultPulsarProducerFactor
 	}
 
 	@Override
-	protected Producer<T> doCreateProducer(String topic, Schema<T> schema, MessageRouter messageRouter, List<ProducerInterceptor> producerInterceptors)
-			throws PulsarClientException {
+	protected Producer<T> doCreateProducer(String topic, Schema<T> schema, MessageRouter messageRouter,
+			List<ProducerInterceptor> producerInterceptors) throws PulsarClientException {
 		Producer<T> producer = super.doCreateProducer(topic, schema, messageRouter, producerInterceptors);
 		return wrapProducerWithCloseCallback(producer,
 				(p) -> this.logger.trace(() -> String.format("Client closed producer %s but will skip actual closing",

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
@@ -57,7 +57,7 @@ public class DefaultPulsarProducerFactory<T> implements PulsarProducerFactory<T>
 
 	@Override
 	public Producer<T> createProducer(String topic, Schema<T> schema) throws PulsarClientException {
-		return createProducer(topic, schema, null);
+		return createProducer(topic, schema, null, null);
 	}
 
 	@Override

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
@@ -27,8 +27,8 @@ import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
-
 import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
+
 import org.springframework.core.log.LogAccessor;
 import org.springframework.util.CollectionUtils;
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
@@ -84,7 +84,7 @@ public class DefaultPulsarProducerFactory<T> implements PulsarProducerFactory<T>
 		if (messageRouter != null) {
 			producerBuilder.messageRouter(messageRouter);
 		}
-		if (producerInterceptors != null && !producerInterceptors.isEmpty()) {
+		if (!CollectionUtils.isEmpty(producerInterceptors)) {
 			producerBuilder.intercept(producerInterceptors.toArray(new ProducerInterceptor[0]));
 		}
 		return producerBuilder.create();

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
@@ -68,12 +68,12 @@ public class DefaultPulsarProducerFactory<T> implements PulsarProducerFactory<T>
 
 	@Override
 	public Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter,
-									  List<ProducerInterceptor> producerInterceptors) throws PulsarClientException {
+			List<ProducerInterceptor> producerInterceptors) throws PulsarClientException {
 		return doCreateProducer(topic, schema, messageRouter, producerInterceptors);
 	}
 
-	protected Producer<T> doCreateProducer(String topic, Schema<T> schema, MessageRouter messageRouter, List<ProducerInterceptor> producerInterceptors)
-			throws PulsarClientException {
+	protected Producer<T> doCreateProducer(String topic, Schema<T> schema, MessageRouter messageRouter,
+			List<ProducerInterceptor> producerInterceptors) throws PulsarClientException {
 		final String resolvedTopic = ProducerUtils.resolveTopicName(topic, this);
 		this.logger.trace(() -> String.format("Creating producer for '%s' topic", resolvedTopic));
 		final ProducerBuilder<T> producerBuilder = this.pulsarClient.newProducer(schema);

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarProducerFactory.java
@@ -16,12 +16,14 @@
 
 package org.springframework.pulsar.core;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 
 /**
  * The strategy to create a {@link Producer} instance(s).
@@ -29,6 +31,7 @@ import org.apache.pulsar.client.api.Schema;
  * @param <T> producer payload type
  * @author Soby Chacko
  * @author Chris Bono
+ * @author Alexander Preuß
  */
 public interface PulsarProducerFactory<T> {
 
@@ -53,6 +56,18 @@ public interface PulsarProducerFactory<T> {
 	 */
 	Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter)
 			throws PulsarClientException;
+
+	/**
+	 * Create a producer.
+	 * @param topic the topic the producer will send messages to or {@code null} to use
+	 * the default topic
+	 * @param schema the schema of the messages to be sent
+	 * @param messageRouter the optional message router to use
+	 * @param producerInterceptors the optional producer interceptors to use
+	 * @return the producer
+	 * @throws PulsarClientException if any error occurs
+	 */
+	Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter, List<ProducerInterceptor> producerInterceptors) throws PulsarClientException;
 
 	/**
 	 * Return a map of configuration options to use when creating producers.

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarProducerFactory.java
@@ -67,7 +67,8 @@ public interface PulsarProducerFactory<T> {
 	 * @return the producer
 	 * @throws PulsarClientException if any error occurs
 	 */
-	Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter, List<ProducerInterceptor> producerInterceptors) throws PulsarClientException;
+	Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter,
+			List<ProducerInterceptor> producerInterceptors) throws PulsarClientException;
 
 	/**
 	 * Return a map of configuration options to use when creating producers.

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
@@ -16,6 +16,7 @@
 
 package org.springframework.pulsar.core;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.logging.LogFactory;
@@ -26,6 +27,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 
+import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 import org.springframework.core.log.LogAccessor;
 
 /**
@@ -42,13 +44,25 @@ public class PulsarTemplate<T> implements PulsarOperations<T> {
 
 	private final PulsarProducerFactory<T> producerFactory;
 
+	private final List<ProducerInterceptor> interceptors;
+
 	/**
 	 * Constructs a template instance.
 	 * @param producerFactory the producer factory used to create the backing Pulsar
 	 * producers.
 	 */
 	public PulsarTemplate(PulsarProducerFactory<T> producerFactory) {
+		this(producerFactory, null);
+	}
+
+	/**
+	 * Constructs a template instance.
+	 * @param producerFactory the producer factory used to create the backing Pulsar producers.
+	 * @param interceptors the {@link ProducerInterceptor}s to add to the producer.
+	 */
+	public PulsarTemplate(PulsarProducerFactory<T> producerFactory, List<ProducerInterceptor> interceptors) {
 		this.producerFactory = producerFactory;
+		this.interceptors = interceptors;
 	}
 
 	@Override
@@ -89,7 +103,7 @@ public class PulsarTemplate<T> implements PulsarOperations<T> {
 	private Producer<T> prepareProducerForSend(String topic, T message, MessageRouter messageRouter)
 			throws PulsarClientException {
 		Schema<T> schema = SchemaUtils.getSchema(message);
-		return this.producerFactory.createProducer(topic, schema, messageRouter);
+		return this.producerFactory.createProducer(topic, schema, messageRouter, interceptors);
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
@@ -26,8 +26,8 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
-
 import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
+
 import org.springframework.core.log.LogAccessor;
 
 /**
@@ -104,7 +104,7 @@ public class PulsarTemplate<T> implements PulsarOperations<T> {
 	private Producer<T> prepareProducerForSend(String topic, T message, MessageRouter messageRouter)
 			throws PulsarClientException {
 		Schema<T> schema = SchemaUtils.getSchema(message);
-		return this.producerFactory.createProducer(topic, schema, messageRouter, interceptors);
+		return this.producerFactory.createProducer(topic, schema, messageRouter, this.interceptors);
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
@@ -57,7 +57,8 @@ public class PulsarTemplate<T> implements PulsarOperations<T> {
 
 	/**
 	 * Constructs a template instance.
-	 * @param producerFactory the producer factory used to create the backing Pulsar producers.
+	 * @param producerFactory the producer factory used to create the backing Pulsar
+	 * producers.
 	 * @param interceptors the {@link ProducerInterceptor}s to add to the producer.
 	 */
 	public PulsarTemplate(PulsarProducerFactory<T> producerFactory, List<ProducerInterceptor> interceptors) {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
@@ -18,7 +18,6 @@ package org.springframework.pulsar.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.in;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
@@ -190,8 +190,9 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 
 	@Override
 	protected void assertProducerHasTopicSchemaAndRouter(Producer<String> producer, String topic, Schema<String> schema,
-														 MessageRouter router, List<ProducerInterceptor> producerInterceptors) {
-		super.assertProducerHasTopicSchemaAndRouter(actualProducerFrom(producer), topic, schema, router, producerInterceptors);
+			MessageRouter router, List<ProducerInterceptor> producerInterceptors) {
+		super.assertProducerHasTopicSchemaAndRouter(actualProducerFrom(producer), topic, schema, router,
+				producerInterceptors);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
@@ -36,6 +36,7 @@ import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 import org.apache.pulsar.client.impl.schema.StringSchema;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -58,6 +59,7 @@ import com.github.benmanes.caffeine.cache.Cache;
  * Tests for {@link CachingPulsarProducerFactory}.
  *
  * @author Chris Bono
+ * @author Alexander Preuß
  */
 class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 
@@ -188,8 +190,8 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 
 	@Override
 	protected void assertProducerHasTopicSchemaAndRouter(Producer<String> producer, String topic, Schema<String> schema,
-			MessageRouter router) {
-		super.assertProducerHasTopicSchemaAndRouter(actualProducerFrom(producer), topic, schema, router);
+														 MessageRouter router, List<ProducerInterceptor> producerInterceptors) {
+		super.assertProducerHasTopicSchemaAndRouter(actualProducerFrom(producer), topic, schema, router, producerInterceptors);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
@@ -18,6 +18,7 @@ package org.springframework.pulsar.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.in;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -78,7 +79,7 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 	@Test
 	void createProducerMultipleCalls() throws PulsarClientException {
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient, Collections.emptyMap());
-		ProducerCacheKey<String> cacheKey = new ProducerCacheKey<>(schema, "topic1", null);
+		ProducerCacheKey<String> cacheKey = new ProducerCacheKey<>(schema, "topic1", null, null);
 
 		Producer<String> producer1 = producerFactory.createProducer("topic1", schema);
 		Producer<String> producer2 = producerFactory.createProducer("topic1", new StringSchema());
@@ -113,32 +114,59 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 		Schema<String> schema2 = new StringSchema();
 		MessageRouter router1 = mock(MessageRouter.class);
 		MessageRouter router2 = mock(MessageRouter.class);
+		List<ProducerInterceptor> interceptors1 = List.of(mock(ProducerInterceptor.class));
+		List<ProducerInterceptor> interceptors2 = List.of(mock(ProducerInterceptor.class));
 
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient, Collections.emptyMap());
 
-		// ask for the same 9 unique combos 3x - should end up w/ only 9 entries in cache
+		// ask for the same 21 unique combos 3x - should end up w/ only 21 entries in
+		// cache
 		for (int i = 0; i < 3; i++) {
 			producerFactory.createProducer(topic1, schema1);
 			producerFactory.createProducer(topic1, schema1, router1);
 			producerFactory.createProducer(topic1, schema1, router2);
+			producerFactory.createProducer(topic1, schema1, router1, interceptors1);
+			producerFactory.createProducer(topic1, schema1, router1, interceptors2);
+			producerFactory.createProducer(topic1, schema1, router2, interceptors1);
+			producerFactory.createProducer(topic1, schema1, router2, interceptors2);
 			producerFactory.createProducer(topic1, schema2);
 			producerFactory.createProducer(topic1, schema2, router1);
 			producerFactory.createProducer(topic1, schema2, router2);
+			producerFactory.createProducer(topic1, schema2, router1, interceptors1);
+			producerFactory.createProducer(topic1, schema2, router1, interceptors2);
+			producerFactory.createProducer(topic1, schema2, router2, interceptors1);
+			producerFactory.createProducer(topic1, schema2, router2, interceptors2);
 			producerFactory.createProducer(topic2, schema1);
 			producerFactory.createProducer(topic2, schema1, router1);
 			producerFactory.createProducer(topic2, schema1, router2);
+			producerFactory.createProducer(topic2, schema1, router1, interceptors1);
+			producerFactory.createProducer(topic2, schema1, router1, interceptors2);
+			producerFactory.createProducer(topic2, schema1, router2, interceptors1);
+			producerFactory.createProducer(topic2, schema1, router2, interceptors2);
 		}
 
 		List<ProducerCacheKey<String>> expectedCacheKeys = new ArrayList<>();
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router1));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router2));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router1));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router2));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router1));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, null, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router1, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router1, interceptors1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router1, interceptors2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router2, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router2, interceptors1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router2, interceptors2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, null, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router1, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router1, interceptors1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router1, interceptors2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router2, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router2, interceptors1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router2, interceptors2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, null, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router1, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router1, interceptors1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router1, interceptors2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router2, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router2, interceptors1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router2, interceptors2));
 
 		getAssertedProducerCache(producerFactory, expectedCacheKeys);
 	}
@@ -146,8 +174,8 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 	@Test
 	void factoryDestroyCleansUpCacheAndClosesProducers() throws PulsarClientException {
 		CachingPulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient, Collections.emptyMap());
-		ProducerCacheKey<String> cacheKey1 = new ProducerCacheKey<>(schema, "topic1", null);
-		ProducerCacheKey<String> cacheKey2 = new ProducerCacheKey<>(schema, "topic2", null);
+		ProducerCacheKey<String> cacheKey1 = new ProducerCacheKey<>(schema, "topic1", null, null);
+		ProducerCacheKey<String> cacheKey2 = new ProducerCacheKey<>(schema, "topic2", null, null);
 
 		Producer<String> actualProducer1 = actualProducerFrom(producerFactory.createProducer("topic1", schema));
 		Producer<String> actualProducer2 = actualProducerFrom(producerFactory.createProducer("topic2", schema));
@@ -166,7 +194,7 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 	void producerEvictedFromCache() throws PulsarClientException {
 		CachingPulsarProducerFactory<String> producerFactory = new CachingPulsarProducerFactory<>(pulsarClient,
 				Collections.emptyMap(), Duration.ofSeconds(3L), 10L, 2);
-		ProducerCacheKey<String> cacheKey = new ProducerCacheKey<>(schema, "topic1", null);
+		ProducerCacheKey<String> cacheKey = new ProducerCacheKey<>(schema, "topic1", null, null);
 
 		Producer<String> actualProducer = actualProducerFrom(producerFactory.createProducer("topic1", schema));
 
@@ -221,7 +249,7 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 	protected CachingPulsarProducerFactory<String> producerFactory(PulsarClient pulsarClient,
 			Map<String, Object> producerConfig) {
 		CachingPulsarProducerFactory<String> producerFactory = new CachingPulsarProducerFactory<>(pulsarClient,
-				producerConfig, Duration.ofMinutes(5L), 10L, 2);
+				producerConfig, Duration.ofMinutes(5L), 30L, 2);
 		producerFactories.add(producerFactory);
 		return producerFactory;
 	}
@@ -231,13 +259,13 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 
 		@Test
 		void nullSchemaIsNotAllowed() {
-			assertThatThrownBy(() -> new ProducerCacheKey<>(null, "topic1", null))
+			assertThatThrownBy(() -> new ProducerCacheKey<>(null, "topic1", null, null))
 					.isInstanceOf(IllegalArgumentException.class).hasMessage("'schema' must be non-null");
 		}
 
 		@Test
 		void nullTopicIsNotAllowed() {
-			assertThatThrownBy(() -> new ProducerCacheKey<>(schema, null, null))
+			assertThatThrownBy(() -> new ProducerCacheKey<>(schema, null, null, null))
 					.isInstanceOf(IllegalArgumentException.class).hasMessage("'topic' must be non-null");
 		}
 
@@ -252,32 +280,49 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 
 		static Stream<Arguments> equalsAndHashCodeTestProvider() {
 			MessageRouter router1 = mock(MessageRouter.class);
-			ProducerCacheKey<String> key1 = new ProducerCacheKey<>(Schema.STRING, "topic1", router1);
+			List<ProducerInterceptor> interceptors1 = Collections.singletonList(mock(ProducerInterceptor.class));
+			ProducerCacheKey<String> key1 = new ProducerCacheKey<>(Schema.STRING, "topic1", router1, interceptors1);
 			return Stream.of(arguments(Named.of("differentClass", key1), "someStrangeObject", false),
 					arguments(Named.of("null", key1), null, false),
 					arguments(Named.of("sameInstance", key1), key1, true),
 					arguments(
-							Named.of("sameSchemaSameTopicSameNullRouter",
-									new ProducerCacheKey<>(Schema.STRING, "topic1", null)),
-							new ProducerCacheKey<>(Schema.STRING, "topic1", null), true),
+							Named.of("sameSchemaSameTopicSameNullRouterSameNullInterceptors",
+									new ProducerCacheKey<>(Schema.STRING, "topic1", null, null)),
+							new ProducerCacheKey<>(Schema.STRING, "topic1", null, null), true),
 					arguments(
-							Named.of("sameSchemaSameTopicSameNonNullRouter",
-									new ProducerCacheKey<>(Schema.STRING, "topic1", router1)),
-							new ProducerCacheKey<>(Schema.STRING, "topic1", router1), true),
+							Named.of("sameSchemaSameTopicSameNonNullRouterSameNullInterceptors",
+									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, null)),
+							new ProducerCacheKey<>(Schema.STRING, "topic1", router1, null), true),
 					arguments(
 							Named.of("differentSchemaInstanceSameSchemaType",
-									new ProducerCacheKey<>(new StringSchema(), "topic1", router1)),
-							new ProducerCacheKey<>(new StringSchema(), "topic1", router1), true),
-					arguments(Named.of("differentSchemaType", new ProducerCacheKey<>(Schema.STRING, "topic1", router1)),
-							new ProducerCacheKey<>(Schema.INT64, "topic1", router1), false),
-					arguments(Named.of("differentTopic", new ProducerCacheKey<>(Schema.STRING, "topic1", router1)),
-							new ProducerCacheKey<>(Schema.STRING, "topic2", router1), false),
+									new ProducerCacheKey<>(new StringSchema(), "topic1", router1, null)),
+							new ProducerCacheKey<>(new StringSchema(), "topic1", router1, null), true),
+					arguments(
+							Named.of("differentSchemaType",
+									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, interceptors1)),
+							new ProducerCacheKey<>(Schema.INT64, "topic1", router1, interceptors1), false),
+					arguments(
+							Named.of("differentTopic",
+									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, interceptors1)),
+							new ProducerCacheKey<>(Schema.STRING, "topic2", router1, interceptors1), false),
 					arguments(
 							Named.of("differentNonNullRouter",
-									new ProducerCacheKey<>(Schema.STRING, "topic1", router1)),
-							new ProducerCacheKey<>(Schema.STRING, "topic1", mock(MessageRouter.class)), false),
-					arguments(Named.of("differentNullRouter", new ProducerCacheKey<>(Schema.STRING, "topic1", router1)),
-							new ProducerCacheKey<>(Schema.STRING, "topic1", null), false));
+									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, null)),
+							new ProducerCacheKey<>(Schema.STRING, "topic1", mock(MessageRouter.class), null), false),
+					arguments(
+							Named.of("differentNullRouter",
+									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, null)),
+							new ProducerCacheKey<>(Schema.STRING, "topic1", null, null), false),
+					arguments(
+							Named.of("differentNonNullInterceptors",
+									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, interceptors1)),
+							new ProducerCacheKey<>(Schema.STRING, "topic1", router1,
+									Collections.singletonList(mock(ProducerInterceptor.class))),
+							false),
+					arguments(
+							Named.of("differentNullInterceptor",
+									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, interceptors1)),
+							new ProducerCacheKey<>(Schema.STRING, "topic1", null, null), false));
 		}
 
 	}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarProducerFactoryTests.java
@@ -24,8 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.pulsar.client.api.Message;
-import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -104,7 +102,7 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 	void createProducerWithDefaultTopicAndInterceptor() throws PulsarClientException {
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient,
 				Collections.singletonMap("topicName", "topic0"));
-		List<ProducerInterceptor> interceptors = Collections.singletonList(new MockInterceptor());
+		List<ProducerInterceptor> interceptors = Collections.singletonList(mock(ProducerInterceptor.class));
 		try (Producer<String> producer = producerFactory.createProducer(null, schema, null, interceptors)) {
 			assertProducerHasTopicSchemaAndRouter(producer, "topic0", schema, null, interceptors);
 		}
@@ -144,30 +142,5 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 	 */
 	protected abstract PulsarProducerFactory<String> producerFactory(PulsarClient pulsarClient,
 			Map<String, Object> producerConfig);
-
-	@SuppressWarnings("rawtypes")
-	private static class MockInterceptor implements ProducerInterceptor {
-
-		@Override
-		public void close() {
-
-		}
-
-		@Override
-		public boolean eligible(Message message) {
-			return true;
-		}
-
-		@Override
-		public Message beforeSend(Producer producer, Message message) {
-			return null;
-		}
-
-		@Override
-		public void onSendAcknowledgement(Producer producer, Message message, MessageId msgId, Throwable exception) {
-
-		}
-
-	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarProducerFactoryTests.java
@@ -120,7 +120,7 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 	}
 
 	protected void assertProducerHasTopicSchemaAndRouter(Producer<String> producer, String topic, Schema<String> schema,
-														 MessageRouter router, List<ProducerInterceptor> producerInterceptors) {
+			MessageRouter router, List<ProducerInterceptor> producerInterceptors) {
 		assertThat(producer.getTopic()).isEqualTo(topic);
 		assertThat(producer).hasFieldOrPropertyWithValue("schema", schema);
 		assertThat(producer).extracting("conf")
@@ -128,12 +128,11 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 				.extracting(ProducerConfigurationData::getCustomMessageRouter).isSameAs(router);
 		if (producerInterceptors == null) {
 			assertThat(producer).extracting("interceptors").isNull();
-		} else {
+		}
+		else {
 			assertThat(producer).extracting("interceptors")
-				.asInstanceOf(InstanceOfAssertFactories.type(ProducerInterceptors.class))
-				.extracting("interceptors")
-				.asInstanceOf(InstanceOfAssertFactories.type(List.class))
-				.isEqualTo(producerInterceptors);
+					.asInstanceOf(InstanceOfAssertFactories.type(ProducerInterceptors.class)).extracting("interceptors")
+					.asInstanceOf(InstanceOfAssertFactories.type(List.class)).isEqualTo(producerInterceptors);
 		}
 
 	}
@@ -169,6 +168,7 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 		public void onSendAcknowledgement(Producer producer, Message message, MessageId msgId, Throwable exception) {
 
 		}
+
 	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarProducerFactoryTests.java
@@ -18,7 +18,6 @@ package org.springframework.pulsar.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.in;
 import static org.mockito.Mockito.mock;
 
 import java.util.Collections;

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarProducerFactoryTests.java
@@ -18,16 +18,22 @@ package org.springframework.pulsar.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.in;
 import static org.mockito.Mockito.mock;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
+import org.apache.pulsar.client.impl.ProducerInterceptors;
 import org.apache.pulsar.client.impl.conf.ProducerConfigurationData;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
@@ -39,6 +45,7 @@ import org.junit.jupiter.api.Test;
  * {@link CachingPulsarProducerFactory}.
  *
  * @author Chris Bono
+ * @author Alexander Preuß
  */
 abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 
@@ -62,7 +69,7 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 	void createProducerWithSpecificTopic() throws PulsarClientException {
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient, Collections.emptyMap());
 		try (Producer<String> producer = producerFactory.createProducer("topic1", schema)) {
-			assertProducerHasTopicSchemaAndRouter(producer, "topic1", schema, null);
+			assertProducerHasTopicSchemaAndRouter(producer, "topic1", schema, null, null);
 		}
 	}
 
@@ -71,7 +78,7 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient, Collections.emptyMap());
 		MessageRouter router = mock(MessageRouter.class);
 		try (Producer<String> producer = producerFactory.createProducer("topic1", schema, router)) {
-			assertProducerHasTopicSchemaAndRouter(producer, "topic1", schema, router);
+			assertProducerHasTopicSchemaAndRouter(producer, "topic1", schema, router, null);
 		}
 	}
 
@@ -80,7 +87,7 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient,
 				Collections.singletonMap("topicName", "topic0"));
 		try (Producer<String> producer = producerFactory.createProducer(null, schema)) {
-			assertProducerHasTopicSchemaAndRouter(producer, "topic0", schema, null);
+			assertProducerHasTopicSchemaAndRouter(producer, "topic0", schema, null, null);
 		}
 	}
 
@@ -90,7 +97,17 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 				Collections.singletonMap("topicName", "topic0"));
 		MessageRouter router = mock(MessageRouter.class);
 		try (Producer<String> producer = producerFactory.createProducer(null, schema, router)) {
-			assertProducerHasTopicSchemaAndRouter(producer, "topic0", schema, router);
+			assertProducerHasTopicSchemaAndRouter(producer, "topic0", schema, router, null);
+		}
+	}
+
+	@Test
+	void createProducerWithDefaultTopicAndInterceptor() throws PulsarClientException {
+		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient,
+				Collections.singletonMap("topicName", "topic0"));
+		List<ProducerInterceptor> interceptors = Collections.singletonList(new MockInterceptor());
+		try (Producer<String> producer = producerFactory.createProducer(null, schema, null, interceptors)) {
+			assertProducerHasTopicSchemaAndRouter(producer, "topic0", schema, null, interceptors);
 		}
 	}
 
@@ -103,12 +120,22 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 	}
 
 	protected void assertProducerHasTopicSchemaAndRouter(Producer<String> producer, String topic, Schema<String> schema,
-			MessageRouter router) {
+														 MessageRouter router, List<ProducerInterceptor> producerInterceptors) {
 		assertThat(producer.getTopic()).isEqualTo(topic);
 		assertThat(producer).hasFieldOrPropertyWithValue("schema", schema);
 		assertThat(producer).extracting("conf")
 				.asInstanceOf(InstanceOfAssertFactories.type(ProducerConfigurationData.class))
 				.extracting(ProducerConfigurationData::getCustomMessageRouter).isSameAs(router);
+		if (producerInterceptors == null) {
+			assertThat(producer).extracting("interceptors").isNull();
+		} else {
+			assertThat(producer).extracting("interceptors")
+				.asInstanceOf(InstanceOfAssertFactories.type(ProducerInterceptors.class))
+				.extracting("interceptors")
+				.asInstanceOf(InstanceOfAssertFactories.type(List.class))
+				.isEqualTo(producerInterceptors);
+		}
+
 	}
 
 	/**
@@ -119,5 +146,29 @@ abstract class PulsarProducerFactoryTests extends AbstractContainerBaseTests {
 	 */
 	protected abstract PulsarProducerFactory<String> producerFactory(PulsarClient pulsarClient,
 			Map<String, Object> producerConfig);
+
+	@SuppressWarnings("rawtypes")
+	private static class MockInterceptor implements ProducerInterceptor {
+
+		@Override
+		public void close() {
+
+		}
+
+		@Override
+		public boolean eligible(Message message) {
+			return true;
+		}
+
+		@Override
+		public Message beforeSend(Producer producer, Message message) {
+			return null;
+		}
+
+		@Override
+		public void onSendAcknowledgement(Producer producer, Message message, MessageId msgId, Throwable exception) {
+
+		}
+	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
@@ -198,8 +198,7 @@ class PulsarTemplateTests extends AbstractContainerBaseTests {
 				arguments(Named.of("testSingleInterceptor", "iit-topic-1"),
 						Collections.singletonList(mock(ProducerInterceptor.class))),
 				arguments(Named.of("testMultipleInterceptors", "iit-topic-2"),
-						List.of(mock(ProducerInterceptor.class), mock(ProducerInterceptor.class)))
-		);
+						List.of(mock(ProducerInterceptor.class), mock(ProducerInterceptor.class))));
 	}
 
 	private static MessageRouter mockRouter() {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
@@ -20,11 +20,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +42,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TopicMetadata;
+import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -100,7 +104,21 @@ class PulsarTemplateTests extends AbstractContainerBaseTests {
 		}
 	}
 
-	static Stream<Arguments> sendMessageTestProvider() {
+	@ParameterizedTest(name = "{0}")
+	@MethodSource("interceptorInvocationTestProvider")
+	void interceptorInvocationTest(String topic, List<ProducerInterceptor> interceptors) throws Exception {
+		try (PulsarClient client = PulsarClient.builder().serviceUrl(getPulsarBrokerUrl()).build()) {
+			PulsarProducerFactory<String> producerFactory = new DefaultPulsarProducerFactory<>(client,
+					Collections.singletonMap("topicName", topic));
+			PulsarTemplate<String> pulsarTemplate = new PulsarTemplate<>(producerFactory, interceptors);
+			pulsarTemplate.send("test-interceptor");
+			for (ProducerInterceptor interceptor : interceptors) {
+				verify(interceptor, atLeastOnce()).eligible(any(Message.class));
+			}
+		}
+	}
+
+	private static Stream<Arguments> sendMessageTestProvider() {
 		return Stream.of(
 
 				arguments(Named.of("sendMessageToDefaultTopic", "smt-topic-1"),
@@ -173,6 +191,15 @@ class PulsarTemplateTests extends AbstractContainerBaseTests {
 				arguments(Named.of("sendAsyncMessageToSpecificTopicWithCustomizerAndRouter", "smt-topic-16"),
 						Collections.emptyMap(), (SendHandler<CompletableFuture<MessageId>>) PulsarTemplate::sendAsync,
 						sampleMessageKeyCustomizer, mockRouter()));
+	}
+
+	private static Stream<Arguments> interceptorInvocationTestProvider() {
+		return Stream.of(
+				arguments(Named.of("testSingleInterceptor", "iit-topic-1"),
+						Collections.singletonList(mock(ProducerInterceptor.class))),
+				arguments(Named.of("testMultipleInterceptors", "iit-topic-2"),
+						List.of(mock(ProducerInterceptor.class), mock(ProducerInterceptor.class)))
+		);
 	}
 
 	private static MessageRouter mockRouter() {


### PR DESCRIPTION
This PR introduces the ability to add ProducerInterceptors to the underlying producer through the PulsarTemplate and PulsarFactory (#35).
 