### PR TITLE
Detect M1 mac in test and substitute container image (#57)

### DIFF
--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/AbstractContainerBaseTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/AbstractContainerBaseTests.java
@@ -16,16 +16,17 @@
 
 package org.springframework.pulsar.autoconfigure;
 
+import java.util.Locale;
+
 import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.utility.DockerImageName;
 
 abstract class AbstractContainerBaseTests {
 
-	static final DockerImageName PULSAR_IMAGE = DockerImageName.parse("apachepulsar/pulsar:2.10.1");
-
-	static PulsarContainer PULSAR_CONTAINER;
+	static final PulsarContainer PULSAR_CONTAINER;
 
 	static {
+		final DockerImageName PULSAR_IMAGE = isRunningOnMacM1() ? getMacM1PulsarImage() : getStandardPulsarImage();
 		PULSAR_CONTAINER = new PulsarContainer(PULSAR_IMAGE);
 		PULSAR_CONTAINER.start();
 	}
@@ -36,6 +37,20 @@ abstract class AbstractContainerBaseTests {
 
 	protected static String getHttpServiceUrl() {
 		return PULSAR_CONTAINER.getHttpServiceUrl();
+	}
+
+	private static boolean isRunningOnMacM1() {
+		String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+		String osArchitecture = System.getProperty("os.arch").toLowerCase(Locale.ENGLISH);
+		return osName.contains("mac") && osArchitecture.equals("aarch64");
+	}
+
+	private static DockerImageName getStandardPulsarImage() {
+		return DockerImageName.parse("apachepulsar/pulsar:2.10.1");
+	}
+
+	private static DockerImageName getMacM1PulsarImage() {
+		return DockerImageName.parse("kezhenxu94/pulsar").asCompatibleSubstituteFor("apachepulsar/pulsar");
 	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/AbstractContainerBaseTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/AbstractContainerBaseTests.java
@@ -16,16 +16,17 @@
 
 package org.springframework.pulsar.core;
 
+import java.util.Locale;
+
 import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public abstract class AbstractContainerBaseTests {
 
-	static final DockerImageName PULSAR_IMAGE = DockerImageName.parse("apachepulsar/pulsar:2.10.1");
-
-	static PulsarContainer PULSAR_CONTAINER;
+	static final PulsarContainer PULSAR_CONTAINER;
 
 	static {
+		final DockerImageName PULSAR_IMAGE = isRunningOnMacM1() ? getMacM1PulsarImage() : getStandardPulsarImage();
 		PULSAR_CONTAINER = new PulsarContainer(PULSAR_IMAGE);
 		PULSAR_CONTAINER.start();
 	}
@@ -36,6 +37,20 @@ public abstract class AbstractContainerBaseTests {
 
 	protected static String getHttpServiceUrl() {
 		return PULSAR_CONTAINER.getHttpServiceUrl();
+	}
+
+	private static boolean isRunningOnMacM1() {
+		String osName = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+		String osArchitecture = System.getProperty("os.arch").toLowerCase(Locale.ENGLISH);
+		return osName.contains("mac") && osArchitecture.equals("aarch64");
+	}
+
+	private static DockerImageName getStandardPulsarImage() {
+		return DockerImageName.parse("apachepulsar/pulsar:2.10.1");
+	}
+
+	private static DockerImageName getMacM1PulsarImage() {
+		return DockerImageName.parse("kezhenxu94/pulsar").asCompatibleSubstituteFor("apachepulsar/pulsar");
 	}
 
 }


### PR DESCRIPTION
This is a best-effort solution for issue #57.

It uses the JVMs system properties to detect the M1 architecture.
This solution will fail if the JVM is running through Rosetta emulation. Other approaches that are independent of the JVM suffer similar problems (see [this question about detecting the M1 from the cli](https://stackoverflow.com/questions/65259300/detect-apple-silicon-from-command-line) for example) so I believe there is no really good solution for this edge case. 