### PR TITLE
Fix documentation sections

### DIFF
--- a/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
@@ -627,9 +627,9 @@ public void listen(Foo foo) {
 On the producer side also, for the Java primitive types, the framework can infer the Schema, but for any other types, you need set that on the `PulsarTemmplate`.
 
 
-=== Intercepting messages
+==== Intercepting messages
 
-==== Intercept messages on the Producer
+===== Intercept messages on the Producer
 Adding a `ProducerInterceptor`  allows you to intercept and mutate messages received by the producer before being published to the brokers.
 To do so, you can pass a list of interceptors into the `PulsarTemplate` constructor.
 When using multiple interceptors, the order they are applied in will be the order they appear in the list.


### PR DESCRIPTION
This PR fixes the sections in the documentation.
Currently, everything from 'Intercepting' messages is a separate section instead of being included in 'Using Spring for Apache Pulsar' as seen here:
<img width="374" alt="Screenshot 2022-09-02 at 11 38 19" src="https://user-images.githubusercontent.com/11444089/188111919-01d62fcc-7cbb-406b-b64b-0d42cd7bd5f6.png">
