### PR TITLE
Add AVRO and (inline) KeyValue support for PulsarListener

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/SchemaUtils.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/SchemaUtils.java
@@ -22,6 +22,7 @@ import org.apache.pulsar.client.api.Schema;
  * Utility class for Pulsar schema inference.
  *
  * @author Soby Chacko
+ * @author Alexander Preuß
  */
 public final class SchemaUtils {
 
@@ -29,9 +30,13 @@ public final class SchemaUtils {
 
 	}
 
-	@SuppressWarnings("unchecked")
 	public static <T> Schema<T> getSchema(T message) {
 		final String clazzName = message.getClass().getName();
+		return getSchema(clazzName);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> Schema<T> getSchema(String clazzName) {
 		return switch (clazzName) {
 			case "java.lang.String" -> (Schema<T>) Schema.STRING;
 			case "[B" -> (Schema<T>) Schema.BYTES;


### PR DESCRIPTION
This PR adds support for Avro and KeyValue types in PulsarListener.

Currently, this only supports inline KeyValue types, as we cannot detect which KeyValueEncodingType is used.

Still missing documentation.