### PR TITLE
Nack redelivery backoff changes

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
@@ -163,11 +163,10 @@ public @interface PulsarListener {
 	String concurrency() default "";
 
 	/**
-	 * The bean name of negativeAckRedeliveryBackoff which is provided to the consumer.
-	 * The bean must be an implementation of
-	 * {@link org.apache.pulsar.client.api.RedeliveryBackoff}. When provided, this will be
-	 * used to control the redelivery of messages after a negative ack.
-	 * @return the negativeAckRedeliveryBackoff bean name.
+	 * The bean name or a 'SpEL' expression that resolves to a
+	 * {@link org.apache.pulsar.client.api.RedeliveryBackoff} to use on the consumer to
+	 * control the redelivery backoff of messages after a negative ack.
+	 * @return the bean name or empty string to not set the backoff
 	 */
 	String negativeAckRedeliveryBackoff() default "";
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
@@ -157,9 +157,18 @@ public @interface PulsarListener {
 	 * be a property placeholder or SpEL expression that evaluates to a {@link Number}, in
 	 * which case {@link Number#intValue()} is used to obtain the value.
 	 * <p>
-	 * SpEL {@code #{...}} and property place holders {@code ${...}} are supported.
+	 * SpEL {@code #{...}} and property placeholders {@code ${...}} are supported.
 	 * @return the concurrency.
 	 */
 	String concurrency() default "";
+
+	/**
+	 * The bean name of negativeAckRedeliveryBackoff which is provided to the consumer.
+	 * The bean must be an implementation of
+	 * {@link org.apache.pulsar.client.api.RedeliveryBackoff}. When provided, this will be
+	 * used to control the redelivery of messages after a negative ack.
+	 * @return the negativeAckRedeliveryBackoff bean name.
+	 */
+	String negativeAckRedeliveryBackoff() default "";
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Messages;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
@@ -73,6 +74,8 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 	private MessageHandlerMethodFactory messageHandlerMethodFactory;
 
 	private SmartMessageConverter messagingConverter;
+
+	private RedeliveryBackoff negativeAckRedeliveryBackoff;
 
 	public void setBean(Object bean) {
 		this.bean = bean;
@@ -172,6 +175,8 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 		final SchemaType type = pulsarContainerProperties.getSchema().getSchemaInfo().getType();
 		pulsarContainerProperties.setSchemaType(type);
 
+		container.setNegativeAckRedeliveryBackoff(this.negativeAckRedeliveryBackoff);
+
 		return messageListener;
 	}
 
@@ -243,6 +248,10 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 
 	public void setMessagingConverter(SmartMessageConverter messagingConverter) {
 		this.messagingConverter = messagingConverter;
+	}
+
+	public void setNegativeAckRedeliveryBackoff(RedeliveryBackoff negativeAckRedeliveryBackoff) {
+		this.negativeAckRedeliveryBackoff = negativeAckRedeliveryBackoff;
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
@@ -26,6 +26,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.Schema;
 
 import org.springframework.util.CollectionUtils;
@@ -78,6 +79,12 @@ public class DefaultPulsarConsumerFactory<T> implements PulsarConsumerFactory<T>
 
 		if (!CollectionUtils.isEmpty(properties)) {
 			consumerBuilder.loadConf(properties);
+		}
+
+		if (properties.containsKey("negativeAckRedeliveryBackoff")) {
+			final RedeliveryBackoff negativeAckRedeliveryBackoff = (RedeliveryBackoff) properties
+					.get("negativeAckRedeliveryBackoff");
+			consumerBuilder.negativeAckRedeliveryBackoff(negativeAckRedeliveryBackoff);
 		}
 
 		consumerBuilder.batchReceivePolicy(batchReceivePolicy);

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
@@ -176,6 +176,7 @@ public abstract class AbstractPulsarMessageListenerContainer<T> implements Pulsa
 		}
 	}
 
+	@Override
 	public void setNegativeAckRedeliveryBackoff(RedeliveryBackoff redeliveryBackoff) {
 		this.negativeAckRedeliveryBackoff = redeliveryBackoff;
 	}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
@@ -17,6 +17,7 @@
 package org.springframework.pulsar.listener;
 
 import org.apache.commons.logging.LogFactory;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanNameAware;
@@ -57,6 +58,8 @@ public abstract class AbstractPulsarMessageListenerContainer<T> implements Pulsa
 	protected final Object lifecycleMonitor = new Object();
 
 	private volatile boolean running = false;
+
+	protected RedeliveryBackoff negativeAckRedeliveryBackoff;
 
 	@SuppressWarnings("unchecked")
 	protected AbstractPulsarMessageListenerContainer(PulsarConsumerFactory<? super T> pulsarConsumerFactory,
@@ -171,6 +174,10 @@ public abstract class AbstractPulsarMessageListenerContainer<T> implements Pulsa
 				doStop();
 			}
 		}
+	}
+
+	public void setNegativeAckRedeliveryBackoff(RedeliveryBackoff redeliveryBackoff) {
+		this.negativeAckRedeliveryBackoff = redeliveryBackoff;
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
@@ -181,4 +181,8 @@ public abstract class AbstractPulsarMessageListenerContainer<T> implements Pulsa
 		this.negativeAckRedeliveryBackoff = redeliveryBackoff;
 	}
 
+	public RedeliveryBackoff getNegativeAckRedeliveryBackoff() {
+		return this.negativeAckRedeliveryBackoff;
+	}
+
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
@@ -108,6 +108,7 @@ public class ConcurrentPulsarMessageListenerContainer<T> extends AbstractPulsarM
 			this.executors.add(exec);
 			container.getContainerProperties().setConsumerTaskExecutor(exec);
 		}
+		container.setNegativeAckRedeliveryBackoff(this.negativeAckRedeliveryBackoff);
 	}
 
 	@Override

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
@@ -127,4 +127,8 @@ public class ConcurrentPulsarMessageListenerContainer<T> extends AbstractPulsarM
 		return false;
 	}
 
+	public List<DefaultPulsarMessageListenerContainer<T>> getContainers() {
+		return this.containers;
+	}
+
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
@@ -182,7 +182,6 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 				final PulsarContainerProperties pulsarContainerProperties = getPulsarContainerProperties();
 				Map<String, Object> propertiesToConsumer = extractDirectConsumerProperties();
 				populateAllNecessaryPropertiesIfNeedBe(propertiesToConsumer);
-				retrieveNegativeAckRedeliveryBackoff(propertiesToConsumer);
 
 				final BatchReceivePolicy batchReceivePolicy = new BatchReceivePolicy.Builder()
 						.maxNumMessages(pulsarContainerProperties.getMaxNumMessages())
@@ -206,8 +205,8 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 		private void populateAllNecessaryPropertiesIfNeedBe(Map<String, Object> currentProperties) {
 			if (currentProperties.containsKey("topicNames")) {
 				final String topicsFromMap = (String) currentProperties.get("topicNames");
-				final String[] topicNames = topicsFromMap.split(",");
-				final Set<String> propertiesDefinedTopics = new HashSet<>(Arrays.stream(topicNames).toList());
+				final String[] topicNames = StringUtils.delimitedListToStringArray(topicsFromMap, ",");
+				final Set<String> propertiesDefinedTopics = Set.of(topicNames);
 				if (!propertiesDefinedTopics.isEmpty()) {
 					currentProperties.put("topicNames", propertiesDefinedTopics);
 				}
@@ -236,9 +235,6 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 					currentProperties.put("subscriptionName", this.containerProperties.getSubscriptionName());
 				}
 			}
-		}
-
-		private void retrieveNegativeAckRedeliveryBackoff(Map<String, Object> currentProperties) {
 			final RedeliveryBackoff negativeAckRedeliveryBackoff = DefaultPulsarMessageListenerContainer.this.negativeAckRedeliveryBackoff;
 			if (negativeAckRedeliveryBackoff != null) {
 				currentProperties.put("negativeAckRedeliveryBackoff", negativeAckRedeliveryBackoff);

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
@@ -37,6 +37,7 @@ import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
 import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 
@@ -179,14 +180,16 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 			}
 			try {
 				final PulsarContainerProperties pulsarContainerProperties = getPulsarContainerProperties();
-				Map<String, Object> propertiesToOverride = extractPropertiesToOverride(pulsarContainerProperties);
+				Map<String, Object> propertiesToConsumer = extractDirectConsumerProperties();
+				populateAllNecessaryPropertiesIfNeedBe(propertiesToConsumer);
+				retrieveNegativeAckRedeliveryBackoff(propertiesToConsumer);
 
 				final BatchReceivePolicy batchReceivePolicy = new BatchReceivePolicy.Builder()
 						.maxNumMessages(pulsarContainerProperties.getMaxNumMessages())
 						.maxNumBytes(pulsarContainerProperties.getMaxNumBytes())
 						.timeout(pulsarContainerProperties.getBatchTimeout(), TimeUnit.MILLISECONDS).build();
 				this.consumer = getPulsarConsumerFactory().createConsumer(
-						(Schema) pulsarContainerProperties.getSchema(), batchReceivePolicy, propertiesToOverride);
+						(Schema) pulsarContainerProperties.getSchema(), batchReceivePolicy, propertiesToConsumer);
 				Assert.state(this.consumer != null, "Unable to create a consumer");
 			}
 			catch (PulsarClientException e) {
@@ -194,50 +197,52 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 			}
 		}
 
-		private Map<String, Object> extractPropertiesToOverride(PulsarContainerProperties pulsarContainerProperties) {
-
+		private Map<String, Object> extractDirectConsumerProperties() {
 			Properties propertyOverrides = this.containerProperties.getPulsarConsumerProperties();
+			return propertyOverrides.entrySet().stream().collect(Collectors.toMap(e -> String.valueOf(e.getKey()),
+					Map.Entry::getValue, (prev, next) -> next, HashMap::new));
+		}
 
-			final Map<String, Object> propOverridesAsMap = propertyOverrides.entrySet().stream().collect(Collectors
-					.toMap(e -> String.valueOf(e.getKey()), Map.Entry::getValue, (prev, next) -> next, HashMap::new));
-
-			final Map<String, Object> propertiesToOverride = new HashMap<>(propOverridesAsMap);
-			if (propertiesToOverride.containsKey("topicNames")) {
-				final String topicsFromMap = (String) propertiesToOverride.get("topicNames");
+		private void populateAllNecessaryPropertiesIfNeedBe(Map<String, Object> currentProperties) {
+			if (currentProperties.containsKey("topicNames")) {
+				final String topicsFromMap = (String) currentProperties.get("topicNames");
 				final String[] topicNames = topicsFromMap.split(",");
 				final Set<String> propertiesDefinedTopics = new HashSet<>(Arrays.stream(topicNames).toList());
 				if (!propertiesDefinedTopics.isEmpty()) {
-					propertiesToOverride.put("topicNames", propertiesDefinedTopics);
+					currentProperties.put("topicNames", propertiesDefinedTopics);
 				}
 			}
-
-			if (!propertiesToOverride.containsKey("subscriptionType")) {
-				final SubscriptionType subscriptionType = pulsarContainerProperties.getSubscriptionType();
+			if (!currentProperties.containsKey("subscriptionType")) {
+				final SubscriptionType subscriptionType = this.containerProperties.getSubscriptionType();
 				if (subscriptionType != null) {
-					propertiesToOverride.put("subscriptionType", subscriptionType);
+					currentProperties.put("subscriptionType", subscriptionType);
 				}
 			}
-			if (!propertiesToOverride.containsKey("topicNames")) {
-				final String[] topics = pulsarContainerProperties.getTopics();
+			if (!currentProperties.containsKey("topicNames")) {
+				final String[] topics = this.containerProperties.getTopics();
 				final Set<String> listenerDefinedTopics = new HashSet<>(Arrays.stream(topics).toList());
 				if (!listenerDefinedTopics.isEmpty()) {
-					propertiesToOverride.put("topicNames", listenerDefinedTopics);
+					currentProperties.put("topicNames", listenerDefinedTopics);
 				}
 			}
-
-			if (!propertiesToOverride.containsKey("topicsPattern")) {
-				final String topicsPattern = pulsarContainerProperties.getTopicsPattern();
+			if (!currentProperties.containsKey("topicsPattern")) {
+				final String topicsPattern = this.containerProperties.getTopicsPattern();
 				if (topicsPattern != null) {
-					propertiesToOverride.put("topicsPattern", topicsPattern);
+					currentProperties.put("topicsPattern", topicsPattern);
 				}
 			}
+			if (!currentProperties.containsKey("subscriptionName")) {
+				if (StringUtils.hasText(this.containerProperties.getSubscriptionName())) {
+					currentProperties.put("subscriptionName", this.containerProperties.getSubscriptionName());
+				}
+			}
+		}
 
-			if (!propertiesToOverride.containsKey("subscriptionName")) {
-				if (StringUtils.hasText(pulsarContainerProperties.getSubscriptionName())) {
-					propertiesToOverride.put("subscriptionName", pulsarContainerProperties.getSubscriptionName());
-				}
+		private void retrieveNegativeAckRedeliveryBackoff(Map<String, Object> currentProperties) {
+			final RedeliveryBackoff negativeAckRedeliveryBackoff = DefaultPulsarMessageListenerContainer.this.negativeAckRedeliveryBackoff;
+			if (negativeAckRedeliveryBackoff != null) {
+				currentProperties.put("negativeAckRedeliveryBackoff", negativeAckRedeliveryBackoff);
 			}
-			return propertiesToOverride;
 		}
 
 		@Override
@@ -253,7 +258,6 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 			publishConsumerStartedEvent();
 			while (isRunning()) {
 				Messages<T> messages = null;
-
 				// Always receive messages in batch mode.
 				try {
 					messages = this.consumer.batchReceive();

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarMessageListenerContainer.java
@@ -16,6 +16,8 @@
 
 package org.springframework.pulsar.listener;
 
+import org.apache.pulsar.client.api.RedeliveryBackoff;
+
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.SmartLifecycle;
 
@@ -41,5 +43,7 @@ public interface PulsarMessageListenerContainer extends SmartLifecycle, Disposab
 	default PulsarContainerProperties getContainerProperties() {
 		throw new UnsupportedOperationException("This container doesn't support retrieving its properties");
 	}
+
+	void setNegativeAckRedeliveryBackoff(RedeliveryBackoff redeliveryBackoff);
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/AbstractContainerBaseTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/AbstractContainerBaseTests.java
@@ -16,17 +16,10 @@
 
 package org.springframework.pulsar.core;
 
-import static org.mockito.Mockito.spy;
-
 import java.util.Locale;
 
-import org.apache.pulsar.client.api.Consumer;
 import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.utility.DockerImageName;
-
-import org.springframework.beans.DirectFieldAccessor;
-import org.springframework.pulsar.listener.DefaultPulsarMessageListenerContainer;
-import org.springframework.util.Assert;
 
 public abstract class AbstractContainerBaseTests {
 
@@ -58,49 +51,6 @@ public abstract class AbstractContainerBaseTests {
 
 	private static DockerImageName getMacM1PulsarImage() {
 		return DockerImageName.parse("kezhenxu94/pulsar").asCompatibleSubstituteFor("apachepulsar/pulsar");
-	}
-
-	protected Consumer<?> spyOnConsumer(DefaultPulsarMessageListenerContainer<String> container) {
-		Consumer<?> consumer = getPropertyValue(container, "listenerConsumer.consumer", Consumer.class);
-		consumer = spy(consumer);
-		new DirectFieldAccessor(getPropertyValue(container, "listenerConsumer")).setPropertyValue("consumer", consumer);
-		return consumer;
-	}
-
-	/**
-	 * Uses nested {@link DirectFieldAccessor}s to obtain a property using dotted notation
-	 * to traverse fields; e.g. "foo.bar.baz" will obtain a reference to the baz field of
-	 * the bar field of foo. Adopted from Spring Integration.
-	 * @param root The object.
-	 * @param propertyPath The path.
-	 * @return The field.
-	 */
-	public static Object getPropertyValue(Object root, String propertyPath) {
-		Object value = null;
-		DirectFieldAccessor accessor = new DirectFieldAccessor(root);
-		String[] tokens = propertyPath.split("\\.");
-		for (int i = 0; i < tokens.length; i++) {
-			value = accessor.getPropertyValue(tokens[i]);
-			if (value != null) {
-				accessor = new DirectFieldAccessor(value);
-			}
-			else if (i == tokens.length - 1) {
-				return null;
-			}
-			else {
-				throw new IllegalArgumentException("intermediate property '" + tokens[i] + "' is null");
-			}
-		}
-		return value;
-	}
-
-	@SuppressWarnings("unchecked")
-	public static <T> T getPropertyValue(Object root, String propertyPath, Class<T> type) {
-		Object value = getPropertyValue(root, propertyPath);
-		if (value != null) {
-			Assert.isAssignable(type, value.getClass());
-		}
-		return (T) value;
 	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/AbstractContainerBaseTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/AbstractContainerBaseTests.java
@@ -16,10 +16,17 @@
 
 package org.springframework.pulsar.core;
 
+import static org.mockito.Mockito.spy;
+
 import java.util.Locale;
 
+import org.apache.pulsar.client.api.Consumer;
 import org.testcontainers.containers.PulsarContainer;
 import org.testcontainers.utility.DockerImageName;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.pulsar.listener.DefaultPulsarMessageListenerContainer;
+import org.springframework.util.Assert;
 
 public abstract class AbstractContainerBaseTests {
 
@@ -51,6 +58,49 @@ public abstract class AbstractContainerBaseTests {
 
 	private static DockerImageName getMacM1PulsarImage() {
 		return DockerImageName.parse("kezhenxu94/pulsar").asCompatibleSubstituteFor("apachepulsar/pulsar");
+	}
+
+	protected Consumer<?> spyOnConsumer(DefaultPulsarMessageListenerContainer<String> container) {
+		Consumer<?> consumer = getPropertyValue(container, "listenerConsumer.consumer", Consumer.class);
+		consumer = spy(consumer);
+		new DirectFieldAccessor(getPropertyValue(container, "listenerConsumer")).setPropertyValue("consumer", consumer);
+		return consumer;
+	}
+
+	/**
+	 * Uses nested {@link DirectFieldAccessor}s to obtain a property using dotted notation
+	 * to traverse fields; e.g. "foo.bar.baz" will obtain a reference to the baz field of
+	 * the bar field of foo. Adopted from Spring Integration.
+	 * @param root The object.
+	 * @param propertyPath The path.
+	 * @return The field.
+	 */
+	public static Object getPropertyValue(Object root, String propertyPath) {
+		Object value = null;
+		DirectFieldAccessor accessor = new DirectFieldAccessor(root);
+		String[] tokens = propertyPath.split("\\.");
+		for (int i = 0; i < tokens.length; i++) {
+			value = accessor.getPropertyValue(tokens[i]);
+			if (value != null) {
+				accessor = new DirectFieldAccessor(value);
+			}
+			else if (i == tokens.length - 1) {
+				return null;
+			}
+			else {
+				throw new IllegalArgumentException("intermediate property '" + tokens[i] + "' is null");
+			}
+		}
+		return value;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T getPropertyValue(Object root, String propertyPath, Class<T> type) {
+		Object value = getPropertyValue(root, propertyPath);
+		if (value != null) {
+			Assert.isAssignable(type, value.getClass());
+		}
+		return (T) value;
 	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/ConsumerAcknowledgmentTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/ConsumerAcknowledgmentTests.java
@@ -77,7 +77,7 @@ class ConsumerAcknowledgmentTests extends AbstractContainerBaseTests {
 		DefaultPulsarMessageListenerContainer<String> container = new DefaultPulsarMessageListenerContainer<>(
 				pulsarConsumerFactory, pulsarContainerProperties);
 		container.start();
-		final Consumer<?> containerConsumer = spyOnConsumer(container);
+		final Consumer<?> containerConsumer = ConsumerTestUtils.spyOnConsumer(container);
 
 		CountDownLatch latch = new CountDownLatch(10);
 
@@ -118,7 +118,7 @@ class ConsumerAcknowledgmentTests extends AbstractContainerBaseTests {
 		DefaultPulsarMessageListenerContainer<String> container = new DefaultPulsarMessageListenerContainer<>(
 				pulsarConsumerFactory, pulsarContainerProperties);
 		container.start();
-		final Consumer<?> containerConsumer = spyOnConsumer(container);
+		final Consumer<?> containerConsumer = ConsumerTestUtils.spyOnConsumer(container);
 
 		Map<String, Object> prodConfig = new HashMap<>();
 		prodConfig.put("topicName", "cons-ack-tests-012");
@@ -164,7 +164,7 @@ class ConsumerAcknowledgmentTests extends AbstractContainerBaseTests {
 		DefaultPulsarMessageListenerContainer<String> container = new DefaultPulsarMessageListenerContainer<>(
 				pulsarConsumerFactory, pulsarContainerProperties);
 		container.start();
-		final Consumer<?> containerConsumer = spyOnConsumer(container);
+		final Consumer<?> containerConsumer = ConsumerTestUtils.spyOnConsumer(container);
 
 		AtomicInteger ackCallCount = new AtomicInteger(0);
 		doAnswer(invocation -> {
@@ -239,7 +239,7 @@ class ConsumerAcknowledgmentTests extends AbstractContainerBaseTests {
 		DefaultPulsarMessageListenerContainer<String> container = new DefaultPulsarMessageListenerContainer<>(
 				pulsarConsumerFactory, pulsarContainerProperties);
 		container.start();
-		final Consumer<?> containerConsumer = spyOnConsumer(container);
+		final Consumer<?> containerConsumer = ConsumerTestUtils.spyOnConsumer(container);
 
 		CountDownLatch latch = new CountDownLatch(10);
 
@@ -296,7 +296,7 @@ class ConsumerAcknowledgmentTests extends AbstractContainerBaseTests {
 		DefaultPulsarMessageListenerContainer<String> container = new DefaultPulsarMessageListenerContainer<>(
 				pulsarConsumerFactory, pulsarContainerProperties);
 		container.start();
-		final Consumer<?> containerConsumer = spyOnConsumer(container);
+		final Consumer<?> containerConsumer = ConsumerTestUtils.spyOnConsumer(container);
 
 		Map<String, Object> prodConfig = new HashMap<>();
 		prodConfig.put("topicName", "cons-ack-tests-015");
@@ -344,7 +344,7 @@ class ConsumerAcknowledgmentTests extends AbstractContainerBaseTests {
 		DefaultPulsarMessageListenerContainer<String> container = new DefaultPulsarMessageListenerContainer<>(
 				pulsarConsumerFactory, pulsarContainerProperties);
 		container.start();
-		final Consumer<?> containerConsumer = spyOnConsumer(container);
+		final Consumer<?> containerConsumer = ConsumerTestUtils.spyOnConsumer(container);
 
 		Map<String, Object> prodConfig = new HashMap<>();
 		prodConfig.put("topicName", "cons-ack-tests-016");

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/ConsumerAcknowledgmentTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/ConsumerAcknowledgmentTests.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -47,14 +46,12 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.pulsar.listener.Acknowledgement;
 import org.springframework.pulsar.listener.DefaultPulsarMessageListenerContainer;
 import org.springframework.pulsar.listener.PulsarAcknowledgingMessageListener;
 import org.springframework.pulsar.listener.PulsarBatchMessageListener;
 import org.springframework.pulsar.listener.PulsarContainerProperties;
 import org.springframework.pulsar.listener.PulsarRecordMessageListener;
-import org.springframework.util.Assert;
 
 /**
  * @author Soby Chacko
@@ -365,49 +362,6 @@ class ConsumerAcknowledgmentTests extends AbstractContainerBaseTests {
 				.untilAsserted(() -> verify(containerConsumer, never()).acknowledge(any(Messages.class)));
 		container.stop();
 		pulsarClient.close();
-	}
-
-	private Consumer<?> spyOnConsumer(DefaultPulsarMessageListenerContainer<String> container) {
-		Consumer<?> consumer = getPropertyValue(container, "listenerConsumer.consumer", Consumer.class);
-		consumer = spy(consumer);
-		new DirectFieldAccessor(getPropertyValue(container, "listenerConsumer")).setPropertyValue("consumer", consumer);
-		return consumer;
-	}
-
-	/**
-	 * Uses nested {@link DirectFieldAccessor}s to obtain a property using dotted notation
-	 * to traverse fields; e.g. "foo.bar.baz" will obtain a reference to the baz field of
-	 * the bar field of foo. Adopted from Spring Integration.
-	 * @param root The object.
-	 * @param propertyPath The path.
-	 * @return The field.
-	 */
-	public static Object getPropertyValue(Object root, String propertyPath) {
-		Object value = null;
-		DirectFieldAccessor accessor = new DirectFieldAccessor(root);
-		String[] tokens = propertyPath.split("\\.");
-		for (int i = 0; i < tokens.length; i++) {
-			value = accessor.getPropertyValue(tokens[i]);
-			if (value != null) {
-				accessor = new DirectFieldAccessor(value);
-			}
-			else if (i == tokens.length - 1) {
-				return null;
-			}
-			else {
-				throw new IllegalArgumentException("intermediate property '" + tokens[i] + "' is null");
-			}
-		}
-		return value;
-	}
-
-	@SuppressWarnings("unchecked")
-	public static <T> T getPropertyValue(Object root, String propertyPath, Class<T> type) {
-		Object value = getPropertyValue(root, propertyPath);
-		if (value != null) {
-			Assert.isAssignable(type, value.getClass());
-		}
-		return (T) value;
 	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/ConsumerTestUtils.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/ConsumerTestUtils.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.core;
+
+import static org.mockito.Mockito.spy;
+
+import org.apache.pulsar.client.api.Consumer;
+
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.pulsar.listener.DefaultPulsarMessageListenerContainer;
+import org.springframework.util.Assert;
+
+public final class ConsumerTestUtils {
+
+	private ConsumerTestUtils() {
+
+	}
+
+	/**
+	 * Provides a Mockito spy object for the message listener container.
+	 * @param container container to spy on
+	 * @return the spied container object
+	 */
+	public static Consumer<?> spyOnConsumer(DefaultPulsarMessageListenerContainer<String> container) {
+		Consumer<?> consumer = getPropertyValue(container, "listenerConsumer.consumer", Consumer.class);
+		consumer = spy(consumer);
+		new DirectFieldAccessor(getPropertyValue(container, "listenerConsumer")).setPropertyValue("consumer", consumer);
+		return consumer;
+	}
+
+	/**
+	 * Uses nested {@link DirectFieldAccessor}s to obtain a property using dotted notation
+	 * to traverse fields; e.g. "foo.bar.baz" will obtain a reference to the baz field of
+	 * the bar field of foo. Adopted from Spring Integration.
+	 * @param root The object.
+	 * @param propertyPath The path.
+	 * @return The field.
+	 */
+	public static Object getPropertyValue(Object root, String propertyPath) {
+		Object value = null;
+		DirectFieldAccessor accessor = new DirectFieldAccessor(root);
+		String[] tokens = propertyPath.split("\\.");
+		for (int i = 0; i < tokens.length; i++) {
+			value = accessor.getPropertyValue(tokens[i]);
+			if (value != null) {
+				accessor = new DirectFieldAccessor(value);
+			}
+			else if (i == tokens.length - 1) {
+				return null;
+			}
+			else {
+				throw new IllegalArgumentException("intermediate property '" + tokens[i] + "' is null");
+			}
+		}
+		return value;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T getPropertyValue(Object root, String propertyPath, Class<T> type) {
+		Object value = getPropertyValue(root, propertyPath);
+		if (value != null) {
+			Assert.isAssignable(type, value.getClass());
+		}
+		return (T) value;
+	}
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTests.java
@@ -194,7 +194,8 @@ class DefaultPulsarMessageListenerContainerTests extends AbstractContainerBaseTe
 		// At this point, we should have 6 call to nack. The first send + 5 more resends
 		// due to the backoff setting and the above latch now counted down to zero.
 		// There may be a race condition, the below assertion find an extra nack,
-		// but the probability for that is low as we have a long enough backoff multiplier.
+		// but the probability for that is low as we have a long enough backoff
+		// multiplier.
 		await().atMost(Duration.ofSeconds(10))
 				.untilAsserted(() -> verify(containerConsumer, times(6)).negativeAcknowledge(any(Message.class)));
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTests.java
@@ -17,7 +17,12 @@
 package org.springframework.pulsar.listener;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,9 +31,14 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.client.impl.MultiplierRedeliveryBackoff;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.pulsar.core.AbstractContainerBaseTests;
@@ -136,6 +146,58 @@ class DefaultPulsarMessageListenerContainerTests extends AbstractContainerBaseTe
 		Thread.sleep(2_000);
 		assertThat(messages.size()).isEqualTo(1);
 		assertThat(messages.get(0)).isEqualTo("hello john doe5");
+		container.stop();
+		pulsarClient.close();
+	}
+
+	@Test
+	void negativeAckRedeliveryBackoff() throws Exception {
+		Map<String, Object> config = new HashMap<>();
+		final HashSet<String> strings = new HashSet<>();
+		strings.add("dpmlct-015");
+		config.put("topicNames", strings);
+		config.put("subscriptionName", "dpmlct-sb-015");
+
+		RedeliveryBackoff redeliveryBackoff = MultiplierRedeliveryBackoff.builder().minDelayMs(1000)
+				.maxDelayMs(5 * 1000).build();
+		config.put("negativeAckRedeliveryBackoff", redeliveryBackoff);
+
+		final PulsarClient pulsarClient = PulsarClient.builder().serviceUrl(getPulsarBrokerUrl()).build();
+		final DefaultPulsarConsumerFactory<String> pulsarConsumerFactory = new DefaultPulsarConsumerFactory<>(
+				pulsarClient, config);
+		CountDownLatch latch = new CountDownLatch(10);
+		PulsarContainerProperties pulsarContainerProperties = new PulsarContainerProperties();
+		pulsarContainerProperties.setMessageListener((PulsarRecordMessageListener<?>) (consumer, msg) -> {
+			latch.countDown();
+			if (((String) msg.getValue()).endsWith("4")) {
+				throw new RuntimeException("fail");
+			}
+		});
+		pulsarContainerProperties.setSchema(Schema.STRING);
+		pulsarContainerProperties.setSubscriptionType(SubscriptionType.Shared);
+		DefaultPulsarMessageListenerContainer<String> container = new DefaultPulsarMessageListenerContainer<>(
+				pulsarConsumerFactory, pulsarContainerProperties);
+		container.start();
+
+		final Consumer<?> containerConsumer = spyOnConsumer(container);
+
+		Map<String, Object> prodConfig = new HashMap<>();
+		prodConfig.put("topicName", "dpmlct-015");
+		final DefaultPulsarProducerFactory<String> pulsarProducerFactory = new DefaultPulsarProducerFactory<>(
+				pulsarClient, prodConfig);
+		final PulsarTemplate<String> pulsarTemplate = new PulsarTemplate<>(pulsarProducerFactory);
+		for (int i = 0; i < 5; i++) {
+			pulsarTemplate.send("hello john doe" + i);
+		}
+		assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+
+		// At this point, we should have 6 call to nack. The first send + 5 more resends
+		// due to the backoff setting and the above latch now counted down to zero.
+		// There may be a race condition, the below assertion find an extra nack,
+		// but the probability for that is low as we have a long enough backoff multiplier.
+		await().atMost(Duration.ofSeconds(10))
+				.untilAsserted(() -> verify(containerConsumer, times(6)).negativeAcknowledge(any(Message.class)));
+
 		container.stop();
 		pulsarClient.close();
 	}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTests.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -153,9 +154,7 @@ class DefaultPulsarMessageListenerContainerTests extends AbstractContainerBaseTe
 	@Test
 	void negativeAckRedeliveryBackoff() throws Exception {
 		Map<String, Object> config = new HashMap<>();
-		final HashSet<String> strings = new HashSet<>();
-		strings.add("dpmlct-015");
-		config.put("topicNames", strings);
+		config.put("topicNames", Collections.singleton("dpmlct-015"));
 		config.put("subscriptionName", "dpmlct-sb-015");
 
 		RedeliveryBackoff redeliveryBackoff = MultiplierRedeliveryBackoff.builder().minDelayMs(1000)
@@ -181,8 +180,7 @@ class DefaultPulsarMessageListenerContainerTests extends AbstractContainerBaseTe
 
 		final Consumer<?> containerConsumer = spyOnConsumer(container);
 
-		Map<String, Object> prodConfig = new HashMap<>();
-		prodConfig.put("topicName", "dpmlct-015");
+		Map<String, Object> prodConfig = Collections.singletonMap("topicName", "dpmlct-015");
 		final DefaultPulsarProducerFactory<String> pulsarProducerFactory = new DefaultPulsarProducerFactory<>(
 				pulsarClient, prodConfig);
 		final PulsarTemplate<String> pulsarTemplate = new PulsarTemplate<>(pulsarProducerFactory);

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainerTests.java
@@ -43,6 +43,7 @@ import org.apache.pulsar.client.impl.MultiplierRedeliveryBackoff;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.pulsar.core.AbstractContainerBaseTests;
+import org.springframework.pulsar.core.ConsumerTestUtils;
 import org.springframework.pulsar.core.DefaultPulsarConsumerFactory;
 import org.springframework.pulsar.core.DefaultPulsarProducerFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
@@ -178,7 +179,7 @@ class DefaultPulsarMessageListenerContainerTests extends AbstractContainerBaseTe
 				pulsarConsumerFactory, pulsarContainerProperties);
 		container.start();
 
-		final Consumer<?> containerConsumer = spyOnConsumer(container);
+		final Consumer<?> containerConsumer = ConsumerTestUtils.spyOnConsumer(container);
 
 		Map<String, Object> prodConfig = Collections.singletonMap("topicName", "dpmlct-015");
 		final DefaultPulsarProducerFactory<String> pulsarProducerFactory = new DefaultPulsarProducerFactory<>(

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -19,8 +19,6 @@ package org.springframework.pulsar.listener;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -237,7 +235,8 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 		static CountDownLatch nackRedeliveryBackoffLatch = new CountDownLatch(5);
 
 		@Test
-		void pulsarListenerWithNackRedeliveryBackoff(@Autowired PulsarListenerEndpointRegistry registry) throws Exception {
+		void pulsarListenerWithNackRedeliveryBackoff(@Autowired PulsarListenerEndpointRegistry registry)
+				throws Exception {
 			pulsarTemplate.send("withNegRedeliveryBackoff-test-topic", "hello john doe");
 			assertThat(nackRedeliveryBackoffLatch.await(15, TimeUnit.SECONDS)).isTrue();
 		}
@@ -247,7 +246,7 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 		static class NegativeAckRedeliveryConfig {
 
 			@PulsarListener(id = "withNegRedeliveryBackoff", subscriptionName = "withNegRedeliveryBackoffSubscription",
-					topics= "withNegRedeliveryBackoff-test-topic", negativeAckRedeliveryBackoff = "redeliveryBackoff",
+					topics = "withNegRedeliveryBackoff-test-topic", negativeAckRedeliveryBackoff = "redeliveryBackoff",
 					subscriptionType = "Shared")
 			void listen(String msg) {
 				nackRedeliveryBackoffLatch.countDown();
@@ -256,13 +255,13 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 
 			@Bean
 			public RedeliveryBackoff redeliveryBackoff() {
-				return MultiplierRedeliveryBackoff.builder().minDelayMs(1000)
-						.maxDelayMs(5 * 1000).multiplier(2).build();
+				return MultiplierRedeliveryBackoff.builder().minDelayMs(1000).maxDelayMs(5 * 1000).multiplier(2)
+						.build();
 			}
+
 		}
 
 	}
-
 
 	@Nested
 	class NegativeConcurrency {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -19,6 +19,8 @@ package org.springframework.pulsar.listener;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +31,9 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.impl.MultiplierRedeliveryBackoff;
 import org.apache.pulsar.client.impl.schema.AvroSchema;
 import org.apache.pulsar.client.impl.schema.JSONSchema;
 import org.apache.pulsar.common.schema.KeyValue;
@@ -225,6 +229,40 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 		}
 
 	}
+
+	@Nested
+	@ContextConfiguration(classes = NegativeAckRedeliveryBackoffTest.NegativeAckRedeliveryConfig.class)
+	class NegativeAckRedeliveryBackoffTest {
+
+		static CountDownLatch nackRedeliveryBackoffLatch = new CountDownLatch(5);
+
+		@Test
+		void pulsarListenerWithNackRedeliveryBackoff(@Autowired PulsarListenerEndpointRegistry registry) throws Exception {
+			pulsarTemplate.send("withNegRedeliveryBackoff-test-topic", "hello john doe");
+			assertThat(nackRedeliveryBackoffLatch.await(15, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@EnablePulsar
+		@Configuration
+		static class NegativeAckRedeliveryConfig {
+
+			@PulsarListener(id = "withNegRedeliveryBackoff", subscriptionName = "withNegRedeliveryBackoffSubscription",
+					topics= "withNegRedeliveryBackoff-test-topic", negativeAckRedeliveryBackoff = "redeliveryBackoff",
+					subscriptionType = "Shared")
+			void listen(String msg) {
+				nackRedeliveryBackoffLatch.countDown();
+				throw new RuntimeException("fail " + msg);
+			}
+
+			@Bean
+			public RedeliveryBackoff redeliveryBackoff() {
+				return MultiplierRedeliveryBackoff.builder().minDelayMs(1000)
+						.maxDelayMs(5 * 1000).multiplier(2).build();
+			}
+		}
+
+	}
+
 
 	@Nested
 	class NegativeConcurrency {


### PR DESCRIPTION
For shared subscriptions, Pulsar allows consumers to provide a complex
redelivery backoff mechanism when negatively acknowledging (nack).
Enabling this Pulsar feature through the PulsarListener annotation
and its related components in the framework.

Resolves https://github.com/spring-projects-experimental/spring-pulsar/issues/78