### PR TITLE
Add deadLetterPolicy to PulsarListener

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
@@ -167,15 +167,15 @@ public @interface PulsarListener {
 	 * The bean name or a 'SpEL' expression that resolves to a
 	 * {@link org.apache.pulsar.client.api.RedeliveryBackoff} to use on the consumer to
 	 * control the redelivery backoff of messages after a negative ack.
-	 * @return the bean name or empty string to not set the backoff
+	 * @return the bean name or empty string to not set the backoff.
 	 */
 	String negativeAckRedeliveryBackoff() default "";
 
 	/**
 	 * The bean name or a 'SpEL' expression that resolves to a
 	 * {@link org.apache.pulsar.client.api.DeadLetterPolicy} to use on the consumer to
-	 * configure a maximum message redelivery.
-	 * @return the bean name or empty string to not set any dead letter policy
+	 * configure a dead letter policy for message redelivery.
+	 * @return the bean name or empty string to not set any dead letter policy.
 	 */
 	String deadLetterPolicy() default "";
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
@@ -46,6 +46,7 @@ import org.springframework.pulsar.config.PulsarListenerEndpointRegistry;
  *
  * @author Soby Chacko
  * @author Chris Bono
+ * @author Alexander Preuß
  */
 @Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -169,5 +170,13 @@ public @interface PulsarListener {
 	 * @return the bean name or empty string to not set the backoff
 	 */
 	String negativeAckRedeliveryBackoff() default "";
+
+	/**
+	 * The bean name or a 'SpEL' expression that resolves to a
+	 * {@link org.apache.pulsar.client.api.DeadLetterPolicy} to use on the consumer to
+	 * configure a maximum message redelivery.
+	 * @return the bean name or empty string to not set any dead letter policy
+	 */
+	String deadLetterPolicy() default "";
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.RedeliveryBackoff;
@@ -76,6 +77,8 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 	private SmartMessageConverter messagingConverter;
 
 	private RedeliveryBackoff negativeAckRedeliveryBackoff;
+
+	private DeadLetterPolicy deadLetterPolicy;
 
 	public void setBean(Object bean) {
 		this.bean = bean;
@@ -176,6 +179,7 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 		pulsarContainerProperties.setSchemaType(type);
 
 		container.setNegativeAckRedeliveryBackoff(this.negativeAckRedeliveryBackoff);
+		container.setDeadLetterPolicy(this.deadLetterPolicy);
 
 		return messageListener;
 	}
@@ -252,6 +256,10 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 
 	public void setNegativeAckRedeliveryBackoff(RedeliveryBackoff negativeAckRedeliveryBackoff) {
 		this.negativeAckRedeliveryBackoff = negativeAckRedeliveryBackoff;
+	}
+
+	public void setDeadLetterPolicy(DeadLetterPolicy deadLetterPolicy) {
+		this.deadLetterPolicy = deadLetterPolicy;
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
@@ -79,9 +79,11 @@ public class DefaultPulsarConsumerFactory<T> implements PulsarConsumerFactory<T>
 		final Map<String, Object> properties = new HashMap<>(this.consumerConfig);
 		properties.putAll(propertiesToOverride);
 
+		// Remove deadLetterPolicy from the properties here and save it to re-apply after
+		// calling `loadConf` (https://github.com/apache/pulsar/issues/11646)
 		DeadLetterPolicy deadLetterPolicy = null;
 		if (properties.containsKey("deadLetterPolicy")) {
-			deadLetterPolicy = (DeadLetterPolicy) properties.remove("deadLetterPolicy"); // https://github.com/apache/pulsar/issues/11646
+			deadLetterPolicy = (DeadLetterPolicy) properties.remove("deadLetterPolicy");
 		}
 
 		if (!CollectionUtils.isEmpty(properties)) {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
@@ -17,6 +17,7 @@
 package org.springframework.pulsar.listener;
 
 import org.apache.commons.logging.LogFactory;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.RedeliveryBackoff;
 
 import org.springframework.beans.BeansException;
@@ -35,6 +36,7 @@ import org.springframework.util.Assert;
  *
  * @param <T> message type.
  * @author Soby Chacko
+ * @author Alexander Preuß
  */
 public abstract class AbstractPulsarMessageListenerContainer<T> implements PulsarMessageListenerContainer,
 		BeanNameAware, ApplicationEventPublisherAware, ApplicationContextAware {
@@ -60,6 +62,8 @@ public abstract class AbstractPulsarMessageListenerContainer<T> implements Pulsa
 	private volatile boolean running = false;
 
 	protected RedeliveryBackoff negativeAckRedeliveryBackoff;
+
+	protected DeadLetterPolicy deadLetterPolicy;
 
 	@SuppressWarnings("unchecked")
 	protected AbstractPulsarMessageListenerContainer(PulsarConsumerFactory<? super T> pulsarConsumerFactory,
@@ -183,6 +187,15 @@ public abstract class AbstractPulsarMessageListenerContainer<T> implements Pulsa
 
 	public RedeliveryBackoff getNegativeAckRedeliveryBackoff() {
 		return this.negativeAckRedeliveryBackoff;
+	}
+
+	@Override
+	public void setDeadLetterPolicy(DeadLetterPolicy deadLetterPolicy) {
+		this.deadLetterPolicy = deadLetterPolicy;
+	}
+
+	public DeadLetterPolicy getDeadLetterPolicy() {
+		return this.deadLetterPolicy;
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
  *
  * @param <T> the payload type.
  * @author Soby Chacko
+ * @author Alexander Preuß
  */
 public class ConcurrentPulsarMessageListenerContainer<T> extends AbstractPulsarMessageListenerContainer<T> {
 
@@ -109,6 +110,7 @@ public class ConcurrentPulsarMessageListenerContainer<T> extends AbstractPulsarM
 			container.getContainerProperties().setConsumerTaskExecutor(exec);
 		}
 		container.setNegativeAckRedeliveryBackoff(this.negativeAckRedeliveryBackoff);
+		container.setDeadLetterPolicy(this.deadLetterPolicy);
 	}
 
 	@Override

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
@@ -32,6 +32,7 @@ import java.util.stream.StreamSupport;
 
 import org.apache.pulsar.client.api.BatchReceivePolicy;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageListener;
@@ -238,6 +239,10 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 			final RedeliveryBackoff negativeAckRedeliveryBackoff = DefaultPulsarMessageListenerContainer.this.negativeAckRedeliveryBackoff;
 			if (negativeAckRedeliveryBackoff != null) {
 				currentProperties.put("negativeAckRedeliveryBackoff", negativeAckRedeliveryBackoff);
+			}
+			final DeadLetterPolicy deadLetterPolicy = DefaultPulsarMessageListenerContainer.this.deadLetterPolicy;
+			if (deadLetterPolicy != null) {
+				currentProperties.put("deadLetterPolicy", deadLetterPolicy);
 			}
 		}
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarMessageListenerContainer.java
@@ -16,6 +16,7 @@
 
 package org.springframework.pulsar.listener;
 
+import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.RedeliveryBackoff;
 
 import org.springframework.beans.factory.DisposableBean;
@@ -45,5 +46,7 @@ public interface PulsarMessageListenerContainer extends SmartLifecycle, Disposab
 	}
 
 	void setNegativeAckRedeliveryBackoff(RedeliveryBackoff redeliveryBackoff);
+
+	void setDeadLetterPolicy(DeadLetterPolicy deadLetterPolicy);
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import org.apache.pulsar.client.api.BatchReceivePolicy;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.Schema;
@@ -41,28 +42,30 @@ import org.springframework.pulsar.core.PulsarConsumerFactory;
 
 /**
  * @author Soby Chacko
+ * @author Alexander Preuß
  */
 public class ConcurrentPulsarMessageListenerContainerTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
+	void deadLetterPolicyAppliedOnChildContainer() throws Exception {
+		MockEnvironment env = setupMockEnvironment(SubscriptionType.Shared);
+		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = env.concurrentContainer();
+		DeadLetterPolicy deadLetterPolicy = DeadLetterPolicy.builder().maxRedeliverCount(5).deadLetterTopic("dlq-topic")
+				.retryLetterTopic("retry-topic").build();
+		concurrentContainer.setDeadLetterPolicy(deadLetterPolicy);
+
+		concurrentContainer.start();
+
+		final DefaultPulsarMessageListenerContainer<String> childContainer = concurrentContainer.getContainers().get(0);
+		assertThat(childContainer.getDeadLetterPolicy()).isEqualTo(deadLetterPolicy);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
 	void nackRedeliveryBackoffAppliedOnChildContainer() throws Exception {
-		PulsarConsumerFactory<String> pulsarConsumerFactory = mock(PulsarConsumerFactory.class);
-		Consumer<String> consumer = mock(Consumer.class);
-
-		when(pulsarConsumerFactory.createConsumer(any(Schema.class), any(BatchReceivePolicy.class), any(Map.class)))
-				.thenReturn(consumer);
-
-		when(consumer.batchReceive()).thenReturn(mock(Messages.class));
-
-		PulsarContainerProperties pulsarContainerProperties = new PulsarContainerProperties();
-		pulsarContainerProperties.setSchema(Schema.STRING);
-		pulsarContainerProperties.setSubscriptionType(SubscriptionType.Shared);
-		pulsarContainerProperties.setMessageListener((PulsarRecordMessageListener<?>) (cons, msg) -> {
-		});
-
-		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = new ConcurrentPulsarMessageListenerContainer<>(
-				pulsarConsumerFactory, pulsarContainerProperties);
+		MockEnvironment env = setupMockEnvironment(SubscriptionType.Shared);
+		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = env.concurrentContainer();
 		RedeliveryBackoff redeliveryBackoff = MultiplierRedeliveryBackoff.builder().minDelayMs(1000)
 				.maxDelayMs(5 * 1000).build();
 		concurrentContainer.setNegativeAckRedeliveryBackoff(redeliveryBackoff);
@@ -76,26 +79,14 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	void basicConcurrencyTesting() throws Exception {
-		PulsarConsumerFactory<String> pulsarConsumerFactory = mock(PulsarConsumerFactory.class);
-		Consumer<String> consumer = mock(Consumer.class);
+		MockEnvironment env = setupMockEnvironment(SubscriptionType.Failover);
+		PulsarConsumerFactory<String> pulsarConsumerFactory = env.consumerFactory();
+		Consumer<String> consumer = env.consumer();
+		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = env.concurrentContainer();
 
-		when(pulsarConsumerFactory.createConsumer(any(Schema.class), any(BatchReceivePolicy.class), any(Map.class)))
-				.thenReturn(consumer);
+		concurrentContainer.setConcurrency(3);
 
-		when(consumer.batchReceive()).thenReturn(mock(Messages.class));
-
-		PulsarContainerProperties pulsarContainerProperties = new PulsarContainerProperties();
-		pulsarContainerProperties.setSchema(Schema.STRING);
-		pulsarContainerProperties.setSubscriptionType(SubscriptionType.Failover);
-		pulsarContainerProperties.setMessageListener((PulsarRecordMessageListener<?>) (cons, msg) -> {
-		});
-
-		ConcurrentPulsarMessageListenerContainer<String> container = new ConcurrentPulsarMessageListenerContainer<>(
-				pulsarConsumerFactory, pulsarContainerProperties);
-
-		container.setConcurrency(3);
-
-		container.start();
+		concurrentContainer.start();
 
 		await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> verify(pulsarConsumerFactory, times(3))
 				.createConsumer(any(Schema.class), any(BatchReceivePolicy.class), any(Map.class)));
@@ -105,6 +96,17 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	void exclusiveSubscriptionMustUseSingleThread() throws Exception {
+		MockEnvironment env = setupMockEnvironment(SubscriptionType.Exclusive);
+		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = env.concurrentContainer();
+
+		concurrentContainer.setConcurrency(3);
+
+		assertThatThrownBy(concurrentContainer::start).isInstanceOf(IllegalStateException.class)
+				.hasMessage("concurrency > 1 is not allowed on Exclusive subscription type");
+	}
+
+	@SuppressWarnings("unchecked")
+	private MockEnvironment setupMockEnvironment(SubscriptionType subscriptionType) throws Exception {
 		PulsarConsumerFactory<String> pulsarConsumerFactory = mock(PulsarConsumerFactory.class);
 		Consumer<String> consumer = mock(Consumer.class);
 
@@ -115,16 +117,18 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 
 		PulsarContainerProperties pulsarContainerProperties = new PulsarContainerProperties();
 		pulsarContainerProperties.setSchema(Schema.STRING);
+		pulsarContainerProperties.setSubscriptionType(subscriptionType);
 		pulsarContainerProperties.setMessageListener((PulsarRecordMessageListener<?>) (cons, msg) -> {
 		});
 
-		ConcurrentPulsarMessageListenerContainer<String> container = new ConcurrentPulsarMessageListenerContainer<>(
+		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = new ConcurrentPulsarMessageListenerContainer<>(
 				pulsarConsumerFactory, pulsarContainerProperties);
 
-		container.setConcurrency(3);
+		return new MockEnvironment(pulsarConsumerFactory, consumer, concurrentContainer);
+	}
 
-		assertThatThrownBy(container::start).isInstanceOf(IllegalStateException.class)
-				.hasMessage("concurrency > 1 is not allowed on Exclusive subscription type");
+	private record MockEnvironment(PulsarConsumerFactory<String> consumerFactory, Consumer<String> consumer,
+			ConcurrentPulsarMessageListenerContainer<String> concurrentContainer) {
 	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
@@ -47,9 +47,8 @@ import org.springframework.pulsar.core.PulsarConsumerFactory;
 public class ConcurrentPulsarMessageListenerContainerTests {
 
 	@Test
-	@SuppressWarnings("unchecked")
 	void deadLetterPolicyAppliedOnChildContainer() throws Exception {
-		MockEnvironment env = setupMockEnvironment(SubscriptionType.Shared);
+		PulsarListenerMockComponents env = setupListenerMockComponents(SubscriptionType.Shared);
 		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = env.concurrentContainer();
 		DeadLetterPolicy deadLetterPolicy = DeadLetterPolicy.builder().maxRedeliverCount(5).deadLetterTopic("dlq-topic")
 				.retryLetterTopic("retry-topic").build();
@@ -62,9 +61,8 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	void nackRedeliveryBackoffAppliedOnChildContainer() throws Exception {
-		MockEnvironment env = setupMockEnvironment(SubscriptionType.Shared);
+		PulsarListenerMockComponents env = setupListenerMockComponents(SubscriptionType.Shared);
 		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = env.concurrentContainer();
 		RedeliveryBackoff redeliveryBackoff = MultiplierRedeliveryBackoff.builder().minDelayMs(1000)
 				.maxDelayMs(5 * 1000).build();
@@ -79,7 +77,7 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	void basicConcurrencyTesting() throws Exception {
-		MockEnvironment env = setupMockEnvironment(SubscriptionType.Failover);
+		PulsarListenerMockComponents env = setupListenerMockComponents(SubscriptionType.Failover);
 		PulsarConsumerFactory<String> pulsarConsumerFactory = env.consumerFactory();
 		Consumer<String> consumer = env.consumer();
 		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = env.concurrentContainer();
@@ -94,9 +92,8 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	void exclusiveSubscriptionMustUseSingleThread() throws Exception {
-		MockEnvironment env = setupMockEnvironment(SubscriptionType.Exclusive);
+		PulsarListenerMockComponents env = setupListenerMockComponents(SubscriptionType.Exclusive);
 		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = env.concurrentContainer();
 
 		concurrentContainer.setConcurrency(3);
@@ -106,7 +103,8 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 	}
 
 	@SuppressWarnings("unchecked")
-	private MockEnvironment setupMockEnvironment(SubscriptionType subscriptionType) throws Exception {
+	private PulsarListenerMockComponents setupListenerMockComponents(SubscriptionType subscriptionType)
+			throws Exception {
 		PulsarConsumerFactory<String> pulsarConsumerFactory = mock(PulsarConsumerFactory.class);
 		Consumer<String> consumer = mock(Consumer.class);
 
@@ -124,11 +122,11 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = new ConcurrentPulsarMessageListenerContainer<>(
 				pulsarConsumerFactory, pulsarContainerProperties);
 
-		return new MockEnvironment(pulsarConsumerFactory, consumer, concurrentContainer);
+		return new PulsarListenerMockComponents(pulsarConsumerFactory, consumer, concurrentContainer);
 	}
 
-	private record MockEnvironment(PulsarConsumerFactory<String> consumerFactory, Consumer<String> consumer,
-			ConcurrentPulsarMessageListenerContainer<String> concurrentContainer) {
+	private record PulsarListenerMockComponents(PulsarConsumerFactory<String> consumerFactory,
+			Consumer<String> consumer, ConcurrentPulsarMessageListenerContainer<String> concurrentContainer) {
 	}
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.DeadLetterPolicy;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.RedeliveryBackoff;
 import org.apache.pulsar.client.api.Schema;
@@ -257,6 +258,46 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 			public RedeliveryBackoff redeliveryBackoff() {
 				return MultiplierRedeliveryBackoff.builder().minDelayMs(1000).maxDelayMs(5 * 1000).multiplier(2)
 						.build();
+			}
+
+		}
+
+	}
+
+	@Nested
+	@ContextConfiguration(classes = DeadLetterPolicyTest.DeadLetterPolicyConfig.class)
+	class DeadLetterPolicyTest {
+
+		static CountDownLatch latch = new CountDownLatch(2);
+		static CountDownLatch dlqLatch = new CountDownLatch(1);
+
+		@Test
+		void pulsarListenerWithDeadLetterPolicy() throws Exception {
+			pulsarTemplate.send("dlpt-topic-1", "hello");
+			assertThat(dlqLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@EnablePulsar
+		@Configuration
+		static class DeadLetterPolicyConfig {
+
+			@PulsarListener(id = "deadLetterPolicyListener", subscriptionName = "deadLetterPolicySubscription",
+					topics = "dlpt-topic-1", deadLetterPolicy = "deadLetterPolicy", subscriptionType = "Shared",
+					properties = { "ackTimeoutMillis=1" })
+			void listen(String msg) {
+				latch.countDown();
+				throw new RuntimeException("fail " + msg);
+			}
+
+			@PulsarListener(id = "dlqListener", subscriptionType = "dlqListenerSubscription", topics = "dlq-topic")
+			void listenDlq(String msg) {
+				dlqLatch.countDown();
+			}
+
+			@Bean
+			DeadLetterPolicy deadLetterPolicy() {
+				return DeadLetterPolicy.builder().maxRedeliverCount(1).deadLetterTopic("dlq-topic").build();
 			}
 
 		}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -268,8 +268,9 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 	@ContextConfiguration(classes = DeadLetterPolicyTest.DeadLetterPolicyConfig.class)
 	class DeadLetterPolicyTest {
 
-		private static final CountDownLatch latch = new CountDownLatch(2);
-		private static final CountDownLatch dlqLatch = new CountDownLatch(1);
+		private static CountDownLatch latch = new CountDownLatch(2);
+
+		private static CountDownLatch dlqLatch = new CountDownLatch(1);
 
 		@Test
 		void pulsarListenerWithDeadLetterPolicy() throws Exception {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -268,8 +268,8 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 	@ContextConfiguration(classes = DeadLetterPolicyTest.DeadLetterPolicyConfig.class)
 	class DeadLetterPolicyTest {
 
-		static CountDownLatch latch = new CountDownLatch(2);
-		static CountDownLatch dlqLatch = new CountDownLatch(1);
+		private static final CountDownLatch latch = new CountDownLatch(2);
+		private static final CountDownLatch dlqLatch = new CountDownLatch(1);
 
 		@Test
 		void pulsarListenerWithDeadLetterPolicy() throws Exception {


### PR DESCRIPTION
This PR adds the ability to add DeadLetterPolicy beans to the PulsarListener annotation (#79).
Mostly based on Soby's work done in #85 