### PR TITLE
More Pulsar Consumer Error handling Changes

### DIFF
--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfigurationTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfigurationTests.java
@@ -162,7 +162,7 @@ class PulsarAutoConfigurationTests {
 
 	@Test
 	void customPulsarListenerAnnotationBeanPostProcessorIsRespected() {
-		PulsarListenerAnnotationBeanPostProcessor<String, String> listenerAnnotationBeanPostProcessor = mock(
+		PulsarListenerAnnotationBeanPostProcessor<String> listenerAnnotationBeanPostProcessor = mock(
 				PulsarListenerAnnotationBeanPostProcessor.class);
 		this.contextRunner
 				.withBean("org.springframework.pulsar.config.internalPulsarListenerAnnotationProcessor",

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
@@ -186,4 +186,12 @@ public @interface PulsarListener {
 	 */
 	AckMode ackMode() default AckMode.BATCH;
 
+	/**
+	 * The bean name or a 'SpEL' expression that resolves to a
+	 * {@link org.springframework.pulsar.listener.PulsarConsumerErrorHandler} which is
+	 * used as a Spring provided mechanism to handle errors from processing the message.
+	 * @return the bean name for the consumer error handler or an empty string.
+	 */
+	String pulsarConsumerErrorHandler() default "";
+
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
@@ -46,6 +46,7 @@ import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.pulsar.core.SchemaUtils;
 import org.springframework.pulsar.listener.Acknowledgement;
 import org.springframework.pulsar.listener.ConcurrentPulsarMessageListenerContainer;
+import org.springframework.pulsar.listener.PulsarConsumerErrorHandler;
 import org.springframework.pulsar.listener.PulsarContainerProperties;
 import org.springframework.pulsar.listener.PulsarMessageListenerContainer;
 import org.springframework.pulsar.listener.adapter.HandlerAdapter;
@@ -82,6 +83,9 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 	private RedeliveryBackoff negativeAckRedeliveryBackoff;
 
 	private DeadLetterPolicy deadLetterPolicy;
+
+	@SuppressWarnings("rawtypes")
+	private PulsarConsumerErrorHandler pulsarConsumerErrorHandler;
 
 	public void setBean(Object bean) {
 		this.bean = bean;
@@ -189,6 +193,7 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 
 		container.setNegativeAckRedeliveryBackoff(this.negativeAckRedeliveryBackoff);
 		container.setDeadLetterPolicy(this.deadLetterPolicy);
+		container.setPulsarConsumerErrorHandler(this.pulsarConsumerErrorHandler);
 
 		return messageListener;
 	}
@@ -269,6 +274,11 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 
 	public void setDeadLetterPolicy(DeadLetterPolicy deadLetterPolicy) {
 		this.deadLetterPolicy = deadLetterPolicy;
+	}
+
+	@SuppressWarnings("rawtypes")
+	public void setPulsarConsumerErrorHandler(PulsarConsumerErrorHandler pulsarConsumerErrorHandler) {
+		this.pulsarConsumerErrorHandler = pulsarConsumerErrorHandler;
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
@@ -65,7 +65,7 @@ public abstract class AbstractPulsarMessageListenerContainer<T> implements Pulsa
 
 	protected DeadLetterPolicy deadLetterPolicy;
 
-	private PulsarConsumerErrorHandler<T> pulsarConsumerErrorHandler;
+	protected PulsarConsumerErrorHandler<T> pulsarConsumerErrorHandler;
 
 	@SuppressWarnings("unchecked")
 	protected AbstractPulsarMessageListenerContainer(PulsarConsumerFactory<? super T> pulsarConsumerFactory,
@@ -204,7 +204,8 @@ public abstract class AbstractPulsarMessageListenerContainer<T> implements Pulsa
 		return this.pulsarConsumerErrorHandler;
 	}
 
-	public void setPulsarConsumerErrorHandler(PulsarConsumerErrorHandler<T> pulsarConsumerErrorHandler) {
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public void setPulsarConsumerErrorHandler(PulsarConsumerErrorHandler pulsarConsumerErrorHandler) {
 		this.pulsarConsumerErrorHandler = pulsarConsumerErrorHandler;
 	}
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
@@ -111,6 +111,7 @@ public class ConcurrentPulsarMessageListenerContainer<T> extends AbstractPulsarM
 		}
 		container.setNegativeAckRedeliveryBackoff(this.negativeAckRedeliveryBackoff);
 		container.setDeadLetterPolicy(this.deadLetterPolicy);
+		container.setPulsarConsumerErrorHandler(this.pulsarConsumerErrorHandler);
 	}
 
 	@Override

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarMessageListenerContainer.java
@@ -49,4 +49,7 @@ public interface PulsarMessageListenerContainer extends SmartLifecycle, Disposab
 
 	void setDeadLetterPolicy(DeadLetterPolicy deadLetterPolicy);
 
+	@SuppressWarnings("rawtypes")
+	void setPulsarConsumerErrorHandler(PulsarConsumerErrorHandler pulsarConsumerErrorHandler);
+
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
@@ -39,6 +39,7 @@ import org.apache.pulsar.client.impl.MultiplierRedeliveryBackoff;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.pulsar.core.PulsarConsumerFactory;
+import org.springframework.util.backoff.BackOff;
 
 /**
  * @author Soby Chacko
@@ -72,6 +73,22 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 
 		final DefaultPulsarMessageListenerContainer<String> childContainer = concurrentContainer.getContainers().get(0);
 		assertThat(childContainer.getNegativeAckRedeliveryBackoff()).isEqualTo(redeliveryBackoff);
+	}
+
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	void pulsarConsumerErrorHandlerAppliedOnChildContainer() throws Exception {
+		PulsarListenerMockComponents env = setupListenerMockComponents(SubscriptionType.Shared);
+		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = env.concurrentContainer();
+
+		PulsarConsumerErrorHandler<String> pulsarConsumerErrorHandler = new DefaultPulsarConsumerErrorHandler(
+				mock(PulsarMessageRecovererFactory.class), mock(BackOff.class));
+		concurrentContainer.setPulsarConsumerErrorHandler(pulsarConsumerErrorHandler);
+
+		concurrentContainer.start();
+
+		final DefaultPulsarMessageListenerContainer<String> childContainer = concurrentContainer.getContainers().get(0);
+		assertThat(childContainer.getPulsarConsumerErrorHandler()).isEqualTo(pulsarConsumerErrorHandler);
 	}
 
 	@Test

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -284,7 +284,7 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 	@ContextConfiguration(classes = PulsarConsumerErrorHandlerTest.PulsarConsumerErrorHandlerConfig.class)
 	class PulsarConsumerErrorHandlerTest {
 
-		static CountDownLatch pcehLatch = new CountDownLatch(11);
+		private static CountDownLatch pulsarConsumerErrorHandlerLatch = new CountDownLatch(11);
 
 		private static CountDownLatch dltLatch = new CountDownLatch(1);
 
@@ -292,7 +292,7 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 		void pulsarListenerWithNackRedeliveryBackoff(@Autowired PulsarListenerEndpointRegistry registry)
 				throws Exception {
 			pulsarTemplate.send("pceht-topic", "hello john doe");
-			assertThat(pcehLatch.await(30, TimeUnit.SECONDS)).isTrue();
+			assertThat(pulsarConsumerErrorHandlerLatch.await(10, TimeUnit.SECONDS)).isTrue();
 			assertThat(dltLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		}
 
@@ -303,7 +303,7 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 			@PulsarListener(id = "pceht-id", subscriptionName = "pceht-subscription", topics = "pceht-topic",
 					pulsarConsumerErrorHandler = "pulsarConsumerErrorHandler")
 			void listen(String msg) {
-				pcehLatch.countDown();
+				pulsarConsumerErrorHandlerLatch.countDown();
 				throw new RuntimeException("fail " + msg);
 			}
 


### PR DESCRIPTION
This PR introduces the ability for PulsarListener annotation to provide the name of the PulsarConsumerErrorHandler bean. When such a bean name is provided, the framework properly scans for the bean and delegates it to downstream message listener container.