### PR TITLE
Use SB/SF milestone libs for M1 release

### DIFF
--- a/spring-pulsar-dependencies/build.gradle
+++ b/spring-pulsar-dependencies/build.gradle
@@ -21,10 +21,10 @@ ext {
 	protobufJavaVersion = '3.21.5'
 	pulsarTestcontainersVersion = '1.17.3'
 	pulsarVersion = '2.10.1'
-	reactorVersion = '2020.0.17'
-	springBootVersion = '3.0.0-SNAPSHOT'
+	reactorVersion = '2022.0.0-M4'
+	springBootVersion = '3.0.0-M4'
 	springRetryVersion = '1.3.3'
-	springVersion = '6.0.0-SNAPSHOT'
+	springVersion = '6.0.0-M5'
 }
 
 dependencies {

--- a/spring-pulsar-sample-apps/build.gradle
+++ b/spring-pulsar-sample-apps/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'org.springframework.pulsar.spring-module'
-	id 'org.springframework.boot' version '3.0.0-SNAPSHOT'
+	id 'org.springframework.boot' version '3.0.0-M4'
 }
 
 description = 'Spring Pulsar Sample Applications'

--- a/spring-pulsar-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.springframework.pulsar.autoconfigure.PulsarAutoConfiguration

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/SpringPulsarBootAppSanityTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/SpringPulsarBootAppSanityTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.autoconfigure;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.pulsar.autoconfigure.SpringPulsarBootAppSanityTests.SpringPulsarBootTestApp;
+import org.springframework.pulsar.core.PulsarTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Sanity tests to ensure that {@code Spring Pulsar} can be auto-configured into a Spring
+ * Boot application.
+ *
+ * @author Chris Bono
+ */
+@SpringBootTest(classes = SpringPulsarBootTestApp.class)
+public class SpringPulsarBootAppSanityTests extends AbstractContainerBaseTests {
+
+	@Test
+	void appStartsWithAutoConfiguredSpringPulsarComponents(
+			@Autowired ObjectProvider<PulsarTemplate<String>> pulsarTemplate) {
+		assertThat(pulsarTemplate.getIfAvailable()).isNotNull();
+	}
+
+	@SpringBootConfiguration
+	@EnableAutoConfiguration
+	static class SpringPulsarBootTestApp {
+
+	}
+
+}

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/SpringPulsarBootAppSanityTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/SpringPulsarBootAppSanityTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.pulsar.autoconfigure;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -25,8 +27,6 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.pulsar.autoconfigure.SpringPulsarBootAppSanityTests.SpringPulsarBootTestApp;
 import org.springframework.pulsar.core.PulsarTemplate;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Sanity tests to ensure that {@code Spring Pulsar} can be auto-configured into a Spring

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -61,10 +61,11 @@ import org.springframework.util.StringUtils;
  * @param <T> message type.
  * @author Soby Chacko
  * @author Alexander Preuß
+ * @author Chris Bono
  */
 public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMessageListenerContainer<T> {
 
-	private volatile CompletableFuture<?> listenerConsumerFuture;
+	private volatile Future<?> listenerConsumerFuture;
 
 	private volatile Listener listenerConsumer;
 
@@ -97,7 +98,7 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 		this.listenerConsumer = new Listener(messageListener);
 		setRunning(true);
 		this.startLatch = new CountDownLatch(1);
-		this.listenerConsumerFuture = consumerExecutor.submitCompletable(this.listenerConsumer);
+		this.listenerConsumerFuture = consumerExecutor.submit(this.listenerConsumer);
 
 		try {
 			if (!this.startLatch.await(containerProperties.getConsumerStartTimeout().toMillis(),


### PR DESCRIPTION
- Made the following TEMPORARY changes to appease downgrading to SB/SF milestones:
  - Removed `AsynTaskExecutor.submitCompletable` (only in SF snaphot)
  - Revert b188436ab5db56faf713d39593a67e2999864c2e (auto-generated auto-config imports file only in SB snapshot)
- Added SpringBootTest sanity test to catch when auto-config is not in place.

@alpreu @sobychacko 