### PR TITLE
AckTimeout Redlivery Backoff Changes

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListener.java
@@ -174,6 +174,14 @@ public @interface PulsarListener {
 
 	/**
 	 * The bean name or a 'SpEL' expression that resolves to a
+	 * {@link org.apache.pulsar.client.api.RedeliveryBackoff} to use on the consumer to
+	 * control the redelivery backoff of messages after an acknowledgment timeout.
+	 * @return the bean name or empty string to not set the backoff.
+	 */
+	String ackTimeoutRedeliveryBackoff() default "";
+
+	/**
+	 * The bean name or a 'SpEL' expression that resolves to a
 	 * {@link org.apache.pulsar.client.api.DeadLetterPolicy} to use on the consumer to
 	 * configure a dead letter policy for message redelivery.
 	 * @return the bean name or empty string to not set any dead letter policy.

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
@@ -365,6 +365,7 @@ public class PulsarListenerAnnotationBeanPostProcessor<V>
 		endpoint.setBeanFactory(this.beanFactory);
 
 		resolveNegativeAckRedeliveryBackoff(endpoint, pulsarListener);
+		resolveAckTimeoutRedeliveryBackoff(endpoint, pulsarListener);
 		resolveDeadLetterPolicy(endpoint, pulsarListener);
 		resolvePulsarConsumerErrorHandler(endpoint, pulsarListener);
 	}
@@ -398,6 +399,22 @@ public class PulsarListenerAnnotationBeanPostProcessor<V>
 			if (StringUtils.hasText(negativeAckRedeliveryBackoffBeanName)) {
 				endpoint.setNegativeAckRedeliveryBackoff(
 						this.beanFactory.getBean(negativeAckRedeliveryBackoffBeanName, RedeliveryBackoff.class));
+			}
+		}
+	}
+
+	private void resolveAckTimeoutRedeliveryBackoff(MethodPulsarListenerEndpoint<?> endpoint,
+			PulsarListener pulsarListener) {
+		Object ackTimeoutRedeliveryBackoff = resolveExpression(pulsarListener.ackTimeoutRedeliveryBackoff());
+		if (ackTimeoutRedeliveryBackoff instanceof RedeliveryBackoff) {
+			endpoint.setAckTimeoutRedeliveryBackoff((RedeliveryBackoff) ackTimeoutRedeliveryBackoff);
+		}
+		else {
+			String ackTimeoutRedeliveryBackoffBeanName = resolveExpressionAsString(
+					pulsarListener.ackTimeoutRedeliveryBackoff(), "ackTimeoutRedeliveryBackoff");
+			if (StringUtils.hasText(ackTimeoutRedeliveryBackoffBeanName)) {
+				endpoint.setAckTimeoutRedeliveryBackoff(
+						this.beanFactory.getBean(ackTimeoutRedeliveryBackoffBeanName, RedeliveryBackoff.class));
 			}
 		}
 	}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
@@ -82,6 +82,8 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 
 	private RedeliveryBackoff negativeAckRedeliveryBackoff;
 
+	private RedeliveryBackoff ackTimeoutRedeliveryBackoff;
+
 	private DeadLetterPolicy deadLetterPolicy;
 
 	@SuppressWarnings("rawtypes")
@@ -192,6 +194,7 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 		pulsarContainerProperties.setSchemaType(type);
 
 		container.setNegativeAckRedeliveryBackoff(this.negativeAckRedeliveryBackoff);
+		container.setAckTimeoutRedeliveryBackoff(this.ackTimeoutRedeliveryBackoff);
 		container.setDeadLetterPolicy(this.deadLetterPolicy);
 		container.setPulsarConsumerErrorHandler(this.pulsarConsumerErrorHandler);
 
@@ -279,6 +282,10 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 	@SuppressWarnings("rawtypes")
 	public void setPulsarConsumerErrorHandler(PulsarConsumerErrorHandler pulsarConsumerErrorHandler) {
 		this.pulsarConsumerErrorHandler = pulsarConsumerErrorHandler;
+	}
+
+	public void setAckTimeoutRedeliveryBackoff(RedeliveryBackoff ackTimeoutRedeliveryBackoff) {
+		this.ackTimeoutRedeliveryBackoff = ackTimeoutRedeliveryBackoff;
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
@@ -103,7 +103,7 @@ public class DefaultPulsarConsumerFactory<T> implements PulsarConsumerFactory<T>
 		if (properties.containsKey("ackTimeoutRedeliveryBackoff")) {
 			final RedeliveryBackoff ackTimeoutRedeliveryBackoff = (RedeliveryBackoff) properties
 					.get("ackTimeoutRedeliveryBackoff");
-			consumerBuilder.negativeAckRedeliveryBackoff(ackTimeoutRedeliveryBackoff);
+			consumerBuilder.ackTimeoutRedeliveryBackoff(ackTimeoutRedeliveryBackoff);
 		}
 
 		consumerBuilder.batchReceivePolicy(batchReceivePolicy);

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
@@ -100,6 +100,12 @@ public class DefaultPulsarConsumerFactory<T> implements PulsarConsumerFactory<T>
 			consumerBuilder.negativeAckRedeliveryBackoff(negativeAckRedeliveryBackoff);
 		}
 
+		if (properties.containsKey("ackTimeoutRedeliveryBackoff")) {
+			final RedeliveryBackoff ackTimeoutRedeliveryBackoff = (RedeliveryBackoff) properties
+					.get("ackTimeoutRedeliveryBackoff");
+			consumerBuilder.negativeAckRedeliveryBackoff(ackTimeoutRedeliveryBackoff);
+		}
+
 		consumerBuilder.batchReceivePolicy(batchReceivePolicy);
 		Consumer<T> consumer = consumerBuilder.subscribe();
 		this.consumers.add(consumer);

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/AbstractPulsarMessageListenerContainer.java
@@ -63,6 +63,8 @@ public abstract class AbstractPulsarMessageListenerContainer<T> implements Pulsa
 
 	protected RedeliveryBackoff negativeAckRedeliveryBackoff;
 
+	protected RedeliveryBackoff ackTimeoutRedeliveryBackoff;
+
 	protected DeadLetterPolicy deadLetterPolicy;
 
 	protected PulsarConsumerErrorHandler<T> pulsarConsumerErrorHandler;
@@ -187,8 +189,17 @@ public abstract class AbstractPulsarMessageListenerContainer<T> implements Pulsa
 		this.negativeAckRedeliveryBackoff = redeliveryBackoff;
 	}
 
+	@Override
+	public void setAckTimeoutRedeliveryBackoff(RedeliveryBackoff redeliveryBackoff) {
+		this.ackTimeoutRedeliveryBackoff = redeliveryBackoff;
+	}
+
 	public RedeliveryBackoff getNegativeAckRedeliveryBackoff() {
 		return this.negativeAckRedeliveryBackoff;
+	}
+
+	public RedeliveryBackoff getAckTimeoutkRedeliveryBackoff() {
+		return this.ackTimeoutRedeliveryBackoff;
 	}
 
 	@Override

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainer.java
@@ -110,6 +110,7 @@ public class ConcurrentPulsarMessageListenerContainer<T> extends AbstractPulsarM
 			container.getContainerProperties().setConsumerTaskExecutor(exec);
 		}
 		container.setNegativeAckRedeliveryBackoff(this.negativeAckRedeliveryBackoff);
+		container.setAckTimeoutRedeliveryBackoff(this.ackTimeoutRedeliveryBackoff);
 		container.setDeadLetterPolicy(this.deadLetterPolicy);
 		container.setPulsarConsumerErrorHandler(this.pulsarConsumerErrorHandler);
 	}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/DefaultPulsarMessageListenerContainer.java
@@ -246,6 +246,10 @@ public class DefaultPulsarMessageListenerContainer<T> extends AbstractPulsarMess
 			if (negativeAckRedeliveryBackoff != null) {
 				currentProperties.put("negativeAckRedeliveryBackoff", negativeAckRedeliveryBackoff);
 			}
+			final RedeliveryBackoff ackTimeoutRedeliveryBackoff = DefaultPulsarMessageListenerContainer.this.ackTimeoutRedeliveryBackoff;
+			if (ackTimeoutRedeliveryBackoff != null) {
+				currentProperties.put("ackTimeoutRedeliveryBackoff", ackTimeoutRedeliveryBackoff);
+			}
 			final DeadLetterPolicy deadLetterPolicy = DefaultPulsarMessageListenerContainer.this.deadLetterPolicy;
 			if (deadLetterPolicy != null) {
 				currentProperties.put("deadLetterPolicy", deadLetterPolicy);

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarMessageListenerContainer.java
@@ -47,6 +47,8 @@ public interface PulsarMessageListenerContainer extends SmartLifecycle, Disposab
 
 	void setNegativeAckRedeliveryBackoff(RedeliveryBackoff redeliveryBackoff);
 
+	void setAckTimeoutRedeliveryBackoff(RedeliveryBackoff redeliveryBackoff);
+
 	void setDeadLetterPolicy(DeadLetterPolicy deadLetterPolicy);
 
 	@SuppressWarnings("rawtypes")

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/ConcurrentPulsarMessageListenerContainerTests.java
@@ -76,6 +76,20 @@ public class ConcurrentPulsarMessageListenerContainerTests {
 	}
 
 	@Test
+	void ackTimeoutRedeliveryBackoffAppliedOnChildContainer() throws Exception {
+		PulsarListenerMockComponents env = setupListenerMockComponents(SubscriptionType.Exclusive);
+		ConcurrentPulsarMessageListenerContainer<String> concurrentContainer = env.concurrentContainer();
+		RedeliveryBackoff redeliveryBackoff = MultiplierRedeliveryBackoff.builder().minDelayMs(1000)
+				.maxDelayMs(5 * 1000).build();
+		concurrentContainer.setAckTimeoutRedeliveryBackoff(redeliveryBackoff);
+
+		concurrentContainer.start();
+
+		final DefaultPulsarMessageListenerContainer<String> childContainer = concurrentContainer.getContainers().get(0);
+		assertThat(childContainer.getAckTimeoutkRedeliveryBackoff()).isEqualTo(redeliveryBackoff);
+	}
+
+	@Test
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	void pulsarConsumerErrorHandlerAppliedOnChildContainer() throws Exception {
 		PulsarListenerMockComponents env = setupListenerMockComponents(SubscriptionType.Shared);

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -290,7 +290,7 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 		void pulsarListenerWithAckTimeoutRedeliveryBackoff(@Autowired PulsarListenerEndpointRegistry registry)
 				throws Exception {
 			pulsarTemplate.send("withAckTimeoutRedeliveryBackoff-test-topic", "hello john doe");
-			assertThat(ackTimeoutRedeliveryBackoffLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(ackTimeoutRedeliveryBackoffLatch.await(15, TimeUnit.SECONDS)).isTrue();
 		}
 
 		@EnablePulsar
@@ -300,10 +300,11 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 			@PulsarListener(id = "withAckTimeoutRedeliveryBackoff",
 					subscriptionName = "withAckTimeoutRedeliveryBackoffSubscription",
 					topics = "withAckTimeoutRedeliveryBackoff-test-topic",
-					ackTimeoutRedeliveryBackoff = "ackTimeoutRedeliveryBackoff")
+					ackTimeoutRedeliveryBackoff = "ackTimeoutRedeliveryBackoff", subscriptionType = "Shared",
+					properties = { "ackTimeoutMillis=1" })
 			void listen(String msg) {
 				ackTimeoutRedeliveryBackoffLatch.countDown();
-				throw new RuntimeException("fail " + msg);
+				throw new RuntimeException();
 			}
 
 			@Bean

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -281,6 +281,42 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 	}
 
 	@Nested
+	@ContextConfiguration(classes = AckTimeoutkRedeliveryBackoffTest.AckTimeoutRedeliveryConfig.class)
+	class AckTimeoutkRedeliveryBackoffTest {
+
+		static CountDownLatch ackTimeoutRedeliveryBackoffLatch = new CountDownLatch(5);
+
+		@Test
+		void pulsarListenerWithAckTimeoutRedeliveryBackoff(@Autowired PulsarListenerEndpointRegistry registry)
+				throws Exception {
+			pulsarTemplate.send("withAckTimeoutRedeliveryBackoff-test-topic", "hello john doe");
+			assertThat(ackTimeoutRedeliveryBackoffLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+
+		@EnablePulsar
+		@Configuration
+		static class AckTimeoutRedeliveryConfig {
+
+			@PulsarListener(id = "withAckTimeoutRedeliveryBackoff",
+					subscriptionName = "withAckTimeoutRedeliveryBackoffSubscription",
+					topics = "withAckTimeoutRedeliveryBackoff-test-topic",
+					ackTimeoutRedeliveryBackoff = "ackTimeoutRedeliveryBackoff")
+			void listen(String msg) {
+				ackTimeoutRedeliveryBackoffLatch.countDown();
+				throw new RuntimeException("fail " + msg);
+			}
+
+			@Bean
+			public RedeliveryBackoff ackTimeoutRedeliveryBackoff() {
+				return MultiplierRedeliveryBackoff.builder().minDelayMs(1000).maxDelayMs(5 * 1000).multiplier(2)
+						.build();
+			}
+
+		}
+
+	}
+
+	@Nested
 	@ContextConfiguration(classes = PulsarConsumerErrorHandlerTest.PulsarConsumerErrorHandlerConfig.class)
 	class PulsarConsumerErrorHandlerTest {
 


### PR DESCRIPTION
Provide a way to specify ackTimeoutRedeliveryBackoff through PulsarListener annotation.

These changes are similar to the one in which we introduced negativeAckRedeliveryBackoff: https://github.com/spring-projects-experimental/spring-pulsar/commit/cc3842062e970ae4b64ade537d085bd0ec309ac9