### PR TITLE
Batch receive properties not copied properly

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/AbstractPulsarListenerContainerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/AbstractPulsarListenerContainerFactory.java
@@ -16,10 +16,14 @@
 
 package org.springframework.pulsar.config;
 
+import java.util.Arrays;
+
 import org.apache.commons.logging.LogFactory;
 import org.apache.pulsar.client.api.Schema;
 
+import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.PropertyAccessorFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -171,11 +175,27 @@ public abstract class AbstractPulsarListenerContainerFactory<C extends AbstractP
 			instance.setAutoStartup(this.autoStartup);
 		}
 
+		copyProperties(this.containerProperties, instance.getContainerProperties(),
+				Arrays.asList("maxNumMessages", "maxNumBytes", "batchTimeout"));
+
 		JavaUtils.INSTANCE.acceptIfNotNull(this.phase, instance::setPhase)
 				.acceptIfNotNull(this.applicationContext, instance::setApplicationContext)
 				.acceptIfNotNull(this.applicationEventPublisher, instance::setApplicationEventPublisher)
 				.acceptIfNotNull(endpoint.getConsumerProperties(),
 						instance.getContainerProperties()::setPulsarConsumerProperties);
+	}
+
+	/**
+	 * Copy a list of properties from the source object to the target.
+	 * @param source Object source to copy from
+	 * @param target Object target to copy to
+	 * @param requestProperties list of properties to copy from source to target
+	 */
+	public static void copyProperties(Object source, Object target, Iterable<String> requestProperties) {
+		BeanWrapper wrappedSource = PropertyAccessorFactory.forBeanPropertyAccess(source);
+		BeanWrapper wrappedTarget = PropertyAccessorFactory.forBeanPropertyAccess(target);
+
+		requestProperties.forEach(p -> wrappedTarget.setPropertyValue(p, wrappedSource.getPropertyValue(p)));
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
@@ -222,6 +222,9 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 		if (rawClass != null && isContainerType(rawClass)) {
 			resolvableType = resolvableType.getGeneric(0);
 		}
+		if (Message.class.isAssignableFrom(resolvableType.getRawClass())) {
+			resolvableType = resolvableType.getGeneric(0);
+		}
 		return resolvableType;
 	}
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarDeadLetterPublishingRecoverer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarDeadLetterPublishingRecoverer.java
@@ -68,7 +68,8 @@ public class PulsarDeadLetterPublishingRecoverer<T> implements PulsarMessageReco
 				this.pulsarTemplate.newMessage(message.getValue())
 						.withTopic(this.destinationResolver.apply(consumer, message))
 						.withMessageCustomizer(messageBuilder -> messageBuilder.property(EXCEPTION_THROWN_CAUSE,
-								exception.getCause().getMessage()))
+								exception.getCause() == null ? exception.getMessage()
+										: exception.getCause().getMessage()))
 						.sendAsync();
 			}
 			catch (PulsarClientException e) {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarBatchMessagingMessageListenerAdapter.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarBatchMessagingMessageListenerAdapter.java
@@ -82,7 +82,7 @@ public class PulsarBatchMessagingMessageListenerAdapter<V> extends PulsarMessagi
 			}
 		}
 		else {
-			message = null; // optimization since we won't need any conversion to invoke
+			message = MessageBuilder.withPayload(msg).build();
 		}
 		logger.debug(() -> "Processing [" + message + "]");
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarMessagingMessageListenerAdapter.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarMessagingMessageListenerAdapter.java
@@ -227,7 +227,8 @@ public abstract class PulsarMessagingMessageListenerAdapter<V> {
 					&& parameterizedType.getActualTypeArguments().length == 1) {
 
 				Type paramType = parameterizedType.getActualTypeArguments()[0];
-				this.isConsumerRecordList = paramType.equals(Messages.class);
+				this.isConsumerRecordList = paramType instanceof ParameterizedType
+						&& ((ParameterizedType) paramType).getRawType().equals(Message.class);
 				boolean messageHasGeneric = paramType instanceof ParameterizedType && ((ParameterizedType) paramType)
 						.getRawType().equals(org.springframework.messaging.Message.class);
 				this.isMessageList = paramType.equals(org.springframework.messaging.Message.class) || messageHasGeneric;


### PR DESCRIPTION
* When Boot provides properties for batch receive, they are not copied downstream through the ConcurrentPulsarListenerContainerFactory. Fixing this issue.