### PR TITLE
Support Pulsar Headers

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarRecordMessagingMessageListenerAdapter.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/adapter/PulsarRecordMessagingMessageListenerAdapter.java
@@ -45,22 +45,21 @@ public class PulsarRecordMessagingMessageListenerAdapter<V> extends PulsarMessag
 	@Override
 	public void received(Consumer<V> consumer, Message<V> record, @Nullable Acknowledgement acknowledgement) {
 		org.springframework.messaging.Message<?> message = null;
-		if (isConversionNeeded()) {
+		Object theRecord = record;
+		if (isHeaderFound() || isSpringMessage()) {
 			message = toMessagingMessage(record, consumer);
 		}
-		else {
-			// message = NULL_MESSAGE;
+		else if (isSimpleExtraction()) {
+			theRecord = record.getValue();
 		}
+
 		if (logger.isDebugEnabled()) {
 			this.logger.debug("Processing [" + message + "]");
 		}
 		try {
-			Object result = invokeHandler(record, message, consumer, acknowledgement);
-			if (result != null) {
-				// handleResult(result, record, message);
-			}
+			invokeHandler(theRecord, message, consumer, acknowledgement);
 		}
-		catch (Exception e) { // NOSONAR ex flow control
+		catch (Exception e) {
 			throw e;
 		}
 	}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/support/DefaultPulsarMessageHeaderMapper.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/support/DefaultPulsarMessageHeaderMapper.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.support;
+
+import java.util.Map;
+
+import org.apache.pulsar.client.api.Message;
+
+/**
+ * Implementation of {@link PulsarMessageHeaderMapper}.
+ *
+ * @author Soby Chacko
+ */
+public class DefaultPulsarMessageHeaderMapper implements PulsarMessageHeaderMapper {
+
+	@Override
+	public void toHeaders(Message<?> source, Map<String, Object> target) {
+		target.putAll(source.getProperties());
+		if (source.hasKey()) {
+			target.put(PulsarHeaders.KEY, source.getKey());
+			target.put(PulsarHeaders.KEY_BYTES, source.getKeyBytes());
+		}
+		if (source.hasOrderingKey()) {
+			target.put(PulsarHeaders.ORDERING_KEY, source.getOrderingKey());
+		}
+		if (source.hasIndex()) {
+			target.put(PulsarHeaders.INDEX, source.getIndex());
+		}
+		target.put(PulsarHeaders.MESSAGE_ID, source.getMessageId());
+		target.put(PulsarHeaders.BROKER_PUBLISH_TIME, source.getBrokerPublishTime());
+		target.put(PulsarHeaders.EVENT_TIME, source.getEventTime());
+		target.put(PulsarHeaders.MESSAGE_SIZE, source.size());
+		target.put(PulsarHeaders.PRODUCER_NAME, source.getProducerName());
+		target.put(PulsarHeaders.RAW_DATA, source.getData());
+		target.put(PulsarHeaders.PUBLISH_TIME, source.getPublishTime());
+		target.put(PulsarHeaders.REDELIVERY_COUNT, source.getRedeliveryCount());
+		target.put(PulsarHeaders.REPLICATED_FROM, source.getReplicatedFrom());
+		target.put(PulsarHeaders.SCHEMA_VERSION, source.getSchemaVersion());
+		target.put(PulsarHeaders.SEQUENCE_ID, source.getSequenceId());
+		target.put(PulsarHeaders.TOPIC_NAME, source.getTopicName());
+	}
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/support/PulsarHeaders.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/support/PulsarHeaders.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.support;
+
+/**
+ * Pulsar specific message headers.
+ *
+ * @author Soby Chacko
+ */
+public abstract class PulsarHeaders {
+
+	/**
+	 * The prefix for Pulsar headers.
+	 */
+	public static final String PREFIX = "pulsar_";
+
+	/**
+	 * The prefix for the message.
+	 */
+	public static final String PULSAR_MESSAGE = PREFIX + "message_";
+
+	/**
+	 * Prefix for the unique message id.
+	 */
+	public static final String MESSAGE_ID = PULSAR_MESSAGE + "id";
+
+	/**
+	 * Prefix for the raw message data.
+	 */
+	public static final String RAW_DATA = PULSAR_MESSAGE + "raw_data";
+
+	/**
+	 * Prefix for message size.
+	 */
+	public static final String MESSAGE_SIZE = PULSAR_MESSAGE + "size";
+
+	/**
+	 * Prefix for message publish time.
+	 */
+	public static final String PUBLISH_TIME = PULSAR_MESSAGE + "publish_time";
+
+	/**
+	 * Prefix for event time.
+	 */
+	public static final String EVENT_TIME = PULSAR_MESSAGE + "event_time";
+
+	/**
+	 * Prefix for message sequence id.
+	 */
+	public static final String SEQUENCE_ID = PULSAR_MESSAGE + "sequence_id";
+
+	/**
+	 * prefix for the producer name.
+	 */
+	public static final String PRODUCER_NAME = PULSAR_MESSAGE + "producer_name";
+
+	/**
+	 * Prefix for the message key.
+	 */
+	public static final String KEY = PULSAR_MESSAGE + "key";
+
+	/**
+	 * Prefix for the message key as bytes.
+	 */
+	public static final String KEY_BYTES = PULSAR_MESSAGE + "key_bytes";
+
+	/**
+	 * Prefix for the order key.
+	 */
+	public static final String ORDERING_KEY = PULSAR_MESSAGE + "ordering_key";
+
+	/**
+	 * Prefix for the topic name.
+	 */
+	public static final String TOPIC_NAME = PULSAR_MESSAGE + "topic_name";
+
+	/**
+	 * Prefix for redelivery count.
+	 */
+	public static final String REDELIVERY_COUNT = PULSAR_MESSAGE + "redelivery_count";
+
+	/**
+	 * Prefix for schema version.
+	 */
+	public static final String SCHEMA_VERSION = PULSAR_MESSAGE + "schema_version";
+
+	/**
+	 * Prefix for the cluster replicated from.
+	 */
+	public static final String REPLICATED_FROM = PULSAR_MESSAGE + "replicated_from";
+
+	/**
+	 * Prefix for broker publish time.
+	 */
+	public static final String BROKER_PUBLISH_TIME = PULSAR_MESSAGE + "broker_publish_time";
+
+	/**
+	 * Prefix for index.
+	 */
+	public static final String INDEX = PULSAR_MESSAGE + "index";
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/support/PulsarMessageHeaderMapper.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/support/PulsarMessageHeaderMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.support;
+
+import java.util.Map;
+
+import org.apache.pulsar.client.api.Message;
+
+/**
+ * API for Pulsar message header mapper.
+ *
+ * @author Soby Chacko
+ */
+public interface PulsarMessageHeaderMapper {
+
+	/**
+	 * Map from the given message metadata to a map of headers for the eventual
+	 * {@link org.springframework.messaging.MessageHeaders}.
+	 * @param source Pulsar message.
+	 * @param target the target headers.
+	 */
+	void toHeaders(Message<?> source, Map<String, Object> target);
+
+}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -19,6 +19,8 @@ package org.springframework.pulsar.listener;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -27,9 +29,12 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.DeadLetterPolicy;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Messages;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.RedeliveryBackoff;
@@ -49,6 +54,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.pulsar.annotation.EnablePulsar;
 import org.springframework.pulsar.annotation.PulsarListener;
 import org.springframework.pulsar.config.ConcurrentPulsarListenerContainerFactory;
@@ -64,6 +70,7 @@ import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.core.PulsarProducerFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
 import org.springframework.pulsar.core.PulsarTopic;
+import org.springframework.pulsar.support.PulsarHeaders;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -603,6 +610,232 @@ public class PulsarListenerTests extends AbstractContainerBaseTests {
 			@Override
 			public String toString() {
 				return "User{" + "name='" + name + '\'' + ", age=" + age + '}';
+			}
+
+		}
+
+	}
+
+	@Nested
+	@ContextConfiguration(classes = PulsarListenerTests.PulsarHeadersTest.PulsarListerWithHeadersConfig.class)
+	class PulsarHeadersTest {
+
+		static CountDownLatch simpleListenerLatch = new CountDownLatch(1);
+		static CountDownLatch pulsarMessageListenerLatch = new CountDownLatch(1);
+		static CountDownLatch springMessagingMessageListenerLatch = new CountDownLatch(1);
+
+		static volatile String capturedData;
+		static volatile MessageId messageId;
+		static volatile String topicName;
+		static volatile String fooValue;
+		static volatile byte[] rawData;
+
+		static CountDownLatch simpleBatchListenerLatch = new CountDownLatch(1);
+		static CountDownLatch pulsarMessageBatchListenerLatch = new CountDownLatch(1);
+		static CountDownLatch springMessagingMessageBatchListenerLatch = new CountDownLatch(1);
+		static CountDownLatch pulsarMessagesBatchListenerLatch = new CountDownLatch(1);
+
+		static volatile List<String> capturedBatchData;
+		static volatile List<MessageId> batchMessageIds;
+		static volatile List<String> batchTopicNames;
+		static volatile List<String> batchFooValues;
+
+		@Test
+		void simpleListenerWithHeaders() throws Exception {
+			final MessageId messageId = pulsarTemplate.newMessage("hello-simple-listener")
+					.withMessageCustomizer(
+							messageBuilder -> messageBuilder.property("foo", "simpleListenerWithHeaders"))
+					.withTopic("simpleListenerWithHeaders").send();
+			assertThat(simpleListenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(capturedData).isEqualTo("hello-simple-listener");
+			assertThat(PulsarHeadersTest.messageId).isEqualTo(messageId);
+			assertThat(topicName).isEqualTo("persistent://public/default/simpleListenerWithHeaders");
+			assertThat(fooValue).isEqualTo("simpleListenerWithHeaders");
+			assertThat(rawData).isEqualTo("hello-simple-listener".getBytes(StandardCharsets.UTF_8));
+		}
+
+		@Test
+		void pulsarMessageListenerWithHeaders() throws Exception {
+			final MessageId messageId = pulsarTemplate.newMessage("hello-pulsar-message-listener")
+					.withMessageCustomizer(
+							messageBuilder -> messageBuilder.property("foo", "pulsarMessageListenerWithHeaders"))
+					.withTopic("pulsarMessageListenerWithHeaders").send();
+			assertThat(pulsarMessageListenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(capturedData).isEqualTo("hello-pulsar-message-listener");
+			assertThat(PulsarHeadersTest.messageId).isEqualTo(messageId);
+			assertThat(topicName).isEqualTo("persistent://public/default/pulsarMessageListenerWithHeaders");
+			assertThat(fooValue).isEqualTo("pulsarMessageListenerWithHeaders");
+			assertThat(rawData).isEqualTo("hello-pulsar-message-listener".getBytes(StandardCharsets.UTF_8));
+		}
+
+		@Test
+		void springMessagingMessageListenerWithHeaders() throws Exception {
+			final MessageId messageId = pulsarTemplate.newMessage("hello-spring-messaging-message-listener")
+					.withMessageCustomizer(messageBuilder -> messageBuilder.property("foo",
+							"springMessagingMessageListenerWithHeaders"))
+					.withTopic("springMessagingMessageListenerWithHeaders").send();
+			assertThat(springMessagingMessageListenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(capturedData).isEqualTo("hello-spring-messaging-message-listener");
+			assertThat(PulsarHeadersTest.messageId).isEqualTo(messageId);
+			assertThat(topicName).isEqualTo("persistent://public/default/springMessagingMessageListenerWithHeaders");
+			assertThat(fooValue).isEqualTo("springMessagingMessageListenerWithHeaders");
+			assertThat(rawData).isEqualTo("hello-spring-messaging-message-listener".getBytes(StandardCharsets.UTF_8));
+		}
+
+		@Test
+		void simpleBatchListenerWithHeaders() throws Exception {
+			final MessageId messageId = pulsarTemplate.newMessage("hello-simple-batch-listener")
+					.withMessageCustomizer(
+							messageBuilder -> messageBuilder.property("foo", "simpleBatchListenerWithHeaders"))
+					.withTopic("simpleBatchListenerWithHeaders").send();
+			assertThat(simpleBatchListenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(capturedBatchData).containsExactly("hello-simple-batch-listener");
+			assertThat(batchMessageIds).containsExactly(messageId);
+			assertThat(batchTopicNames).containsExactly("persistent://public/default/simpleBatchListenerWithHeaders");
+			assertThat(batchFooValues).containsExactly("simpleBatchListenerWithHeaders");
+		}
+
+		@Test
+		void pulsarMessageBatchListenerWithHeaders() throws Exception {
+			final MessageId messageId = pulsarTemplate.newMessage("hello-pulsar-message-batch-listener")
+					.withMessageCustomizer(
+							messageBuilder -> messageBuilder.property("foo", "pulsarMessageBatchListenerWithHeaders"))
+					.withTopic("pulsarMessageBatchListenerWithHeaders").send();
+			assertThat(pulsarMessageBatchListenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(capturedBatchData).containsExactly("hello-pulsar-message-batch-listener");
+			assertThat(batchTopicNames)
+					.containsExactly("persistent://public/default/pulsarMessageBatchListenerWithHeaders");
+			assertThat(batchFooValues).containsExactly("pulsarMessageBatchListenerWithHeaders");
+			assertThat(batchMessageIds).containsExactly(messageId);
+		}
+
+		@Test
+		void springMessagingMessageBatchListenerWithHeaders() throws Exception {
+			final MessageId messageId = pulsarTemplate.newMessage("hello-spring-messaging-message-batch-listener")
+					.withMessageCustomizer(messageBuilder -> messageBuilder.property("foo",
+							"springMessagingMessageBatchListenerWithHeaders"))
+					.withTopic("springMessagingMessageBatchListenerWithHeaders").send();
+			assertThat(springMessagingMessageBatchListenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(capturedBatchData).containsExactly("hello-spring-messaging-message-batch-listener");
+			assertThat(batchTopicNames)
+					.containsExactly("persistent://public/default/springMessagingMessageBatchListenerWithHeaders");
+			assertThat(batchFooValues).containsExactly("springMessagingMessageBatchListenerWithHeaders");
+			assertThat(batchMessageIds).containsExactly(messageId);
+		}
+
+		@Test
+		void pulsarMessagesBatchListenerWithHeaders() throws Exception {
+			final MessageId messageId = pulsarTemplate.newMessage("hello-pulsar-messages-batch-listener")
+					.withMessageCustomizer(
+							messageBuilder -> messageBuilder.property("foo", "pulsarMessagesBatchListenerWithHeaders"))
+					.withTopic("pulsarMessagesBatchListenerWithHeaders").send();
+			assertThat(pulsarMessagesBatchListenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(capturedBatchData).containsExactly("hello-pulsar-messages-batch-listener");
+			assertThat(batchTopicNames)
+					.containsExactly("persistent://public/default/pulsarMessagesBatchListenerWithHeaders");
+			assertThat(batchFooValues).containsExactly("pulsarMessagesBatchListenerWithHeaders");
+			assertThat(batchMessageIds).containsExactly(messageId);
+		}
+
+		@EnablePulsar
+		@Configuration
+		static class PulsarListerWithHeadersConfig {
+
+			@PulsarListener(subscriptionName = "simple-listener-with-headers-sub", topics = "simpleListenerWithHeaders")
+			void simpleListenerWithHeaders(String data, @Header(PulsarHeaders.MESSAGE_ID) MessageId messageId,
+					@Header(PulsarHeaders.TOPIC_NAME) String topicName, @Header(PulsarHeaders.RAW_DATA) byte[] rawData,
+					@Header("foo") String foo) {
+				capturedData = data;
+				PulsarHeadersTest.messageId = messageId;
+				PulsarHeadersTest.topicName = topicName;
+				fooValue = foo;
+				PulsarHeadersTest.rawData = rawData;
+				simpleListenerLatch.countDown();
+			}
+
+			@PulsarListener(subscriptionName = "pulsar-message-listener-with-headers-sub",
+					topics = "pulsarMessageListenerWithHeaders")
+			void pulsarMessageListenerWithHeaders(Message<String> data,
+					@Header(PulsarHeaders.MESSAGE_ID) MessageId messageId,
+					@Header(PulsarHeaders.TOPIC_NAME) String topicName, @Header(PulsarHeaders.RAW_DATA) byte[] rawData,
+					@Header("foo") String foo) {
+				capturedData = data.getValue();
+				PulsarHeadersTest.messageId = messageId;
+				PulsarHeadersTest.topicName = topicName;
+				fooValue = foo;
+				PulsarHeadersTest.rawData = rawData;
+				pulsarMessageListenerLatch.countDown();
+			}
+
+			@PulsarListener(subscriptionName = "pulsar-message-listener-with-headers-sub",
+					topics = "springMessagingMessageListenerWithHeaders")
+			void springMessagingMessageListenerWithHeaders(org.springframework.messaging.Message<String> data,
+					@Header(PulsarHeaders.MESSAGE_ID) MessageId messageId,
+					@Header(PulsarHeaders.RAW_DATA) byte[] rawData, @Header(PulsarHeaders.TOPIC_NAME) String topicName,
+					@Header("foo") String foo) {
+				capturedData = data.getPayload();
+				PulsarHeadersTest.messageId = messageId;
+				PulsarHeadersTest.topicName = topicName;
+				fooValue = foo;
+				PulsarHeadersTest.rawData = rawData;
+				springMessagingMessageListenerLatch.countDown();
+			}
+
+			@PulsarListener(subscriptionName = "simple-batch-listener-with-headers-sub",
+					topics = "simpleBatchListenerWithHeaders", batch = true)
+			void simpleBatchListenerWithHeaders(List<String> data,
+					@Header(PulsarHeaders.MESSAGE_ID) List<MessageId> messageIds,
+					@Header(PulsarHeaders.TOPIC_NAME) List<String> topicNames, @Header("foo") List<String> fooValues) {
+				capturedBatchData = data;
+				batchMessageIds = messageIds;
+				batchTopicNames = topicNames;
+				batchFooValues = fooValues;
+				simpleBatchListenerLatch.countDown();
+			}
+
+			@PulsarListener(subscriptionName = "pulsarMessage-batch-listener-with-headers-sub",
+					topics = "pulsarMessageBatchListenerWithHeaders", batch = true)
+			void pulsarMessageBatchListenerWithHeaders(List<Message<String>> data,
+					@Header(PulsarHeaders.MESSAGE_ID) List<MessageId> messageIds,
+					@Header(PulsarHeaders.TOPIC_NAME) List<String> topicNames, @Header("foo") List<String> fooValues) {
+
+				capturedBatchData = data.stream().map(Message::getValue).collect(Collectors.toList());
+
+				batchMessageIds = messageIds;
+				batchTopicNames = topicNames;
+				batchFooValues = fooValues;
+				pulsarMessageBatchListenerLatch.countDown();
+			}
+
+			@PulsarListener(subscriptionName = "spring-messaging-message-batch-listener-with-headers-sub",
+					topics = "springMessagingMessageBatchListenerWithHeaders", batch = true)
+			void springMessagingMessageBatchListenerWithHeaders(
+					List<org.springframework.messaging.Message<String>> data,
+					@Header(PulsarHeaders.MESSAGE_ID) List<MessageId> messageIds,
+					@Header(PulsarHeaders.TOPIC_NAME) List<String> topicNames, @Header("foo") List<String> fooValues) {
+
+				capturedBatchData = data.stream().map(org.springframework.messaging.Message::getPayload)
+						.collect(Collectors.toList());
+
+				batchMessageIds = messageIds;
+				batchTopicNames = topicNames;
+				batchFooValues = fooValues;
+				springMessagingMessageBatchListenerLatch.countDown();
+			}
+
+			@PulsarListener(subscriptionName = "pulsarMessages-batch-listener-with-headers-sub",
+					topics = "pulsarMessagesBatchListenerWithHeaders", batch = true)
+			void pulsarMessagesBatchListenerWithHeaders(Messages<String> data,
+					@Header(PulsarHeaders.MESSAGE_ID) List<MessageId> messageIds,
+					@Header(PulsarHeaders.TOPIC_NAME) List<String> topicNames, @Header("foo") List<String> fooValues) {
+				List<String> list = new ArrayList<>();
+				data.iterator().forEachRemaining(m -> list.add(m.getValue()));
+				capturedBatchData = list;
+
+				batchMessageIds = messageIds;
+				batchTopicNames = topicNames;
+				batchFooValues = fooValues;
+				pulsarMessagesBatchListenerLatch.countDown();
 			}
 
 		}


### PR DESCRIPTION
Convert Pulsar Message metadata as PulsarHeaders and make them available on PulsarListener through Spring's @Header annotation.

Resolves https://github.com/spring-projects-experimental/spring-pulsar/issues/150