### PR TITLE
Add observations auto-configuration

### DIFF
--- a/buildSrc/src/main/java/org/springframework/pulsar/gradle/docs/configprops/DocumentConfigurationProperties.java
+++ b/buildSrc/src/main/java/org/springframework/pulsar/gradle/docs/configprops/DocumentConfigurationProperties.java
@@ -65,7 +65,10 @@ public class DocumentConfigurationProperties extends DefaultTask {
 	void documentConfigurationProperties() throws IOException {
 		Snippets snippets = new Snippets(this.configurationPropertyMetadata);
 		snippets.add("application-properties.pulsar-client", "Pulsar Client Properties", (c) -> c.accept("spring.pulsar.client"));
-		snippets.add("application-properties.pulsar-producer", "Pulsar Producer Properties", (c) -> c.accept("spring.pulsar.producer"));
+		snippets.add("application-properties.pulsar-producer", "Pulsar Producer Properties", (c) -> {
+			c.accept("spring.pulsar.producer");
+			c.accept("spring.pulsar.template");
+		});
 		snippets.add("application-properties.pulsar-consumer", "Pulsar Consumer Properties", (c) -> {
 			c.accept("spring.pulsar.consumer");
 			c.accept("spring.pulsar.listener");

--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
@@ -37,6 +37,9 @@ import org.springframework.pulsar.core.PulsarAdministration;
 import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.core.PulsarProducerFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
+import org.springframework.pulsar.observation.PulsarTemplateObservationConvention;
+
+import io.micrometer.observation.ObservationRegistry;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for Apache Pulsar.
@@ -89,8 +92,13 @@ public class PulsarAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(PulsarTemplate.class)
 	public PulsarTemplate<?> pulsarTemplate(PulsarProducerFactory<?> pulsarProducerFactory,
-			ObjectProvider<ProducerInterceptor> interceptors) {
-		return new PulsarTemplate<>(pulsarProducerFactory, interceptors.orderedStream().toList());
+			ObjectProvider<ProducerInterceptor> interceptorsProvider,
+			ObjectProvider<ObservationRegistry> observationRegistryProvider,
+			ObjectProvider<PulsarTemplateObservationConvention> observationConventionProvider) {
+		return new PulsarTemplate<>(pulsarProducerFactory, interceptorsProvider.orderedStream().toList(),
+				this.properties.getTemplate().isObservationsEnabled() ? observationRegistryProvider.getIfUnique()
+						: null,
+				observationConventionProvider.getIfUnique());
 	}
 
 	@Bean

--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarProperties.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarProperties.java
@@ -62,6 +62,8 @@ public class PulsarProperties {
 
 	private final Producer producer = new Producer();
 
+	private final Template template = new Template();
+
 	private final Admin admin = new Admin();
 
 	public Consumer getConsumer() {
@@ -78,6 +80,10 @@ public class PulsarProperties {
 
 	public Producer getProducer() {
 		return this.producer;
+	}
+
+	public Template getTemplate() {
+		return this.template;
 	}
 
 	public Admin getAdministration() {
@@ -687,6 +693,24 @@ public class PulsarProperties {
 			map.from(this::getProducerAccessMode).to(properties.in("accessMode"));
 
 			return properties;
+		}
+
+	}
+
+	public static class Template {
+
+		/**
+		 * Whether to record observations for send operations when the Observations API is
+		 * available.
+		 */
+		private boolean observationsEnabled = true;
+
+		public boolean isObservationsEnabled() {
+			return this.observationsEnabled;
+		}
+
+		public void setObservationsEnabled(boolean observationsEnabled) {
+			this.observationsEnabled = observationsEnabled;
 		}
 
 	}
@@ -1339,6 +1363,12 @@ public class PulsarProperties {
 		 */
 		private int batchTimeoutMillis = 100;
 
+		/**
+		 * Whether to record observations for receive operations when the Observations API
+		 * is available.
+		 */
+		private boolean observationsEnabled = true;
+
 		public AckMode getAckMode() {
 			return this.ackMode;
 		}
@@ -1377,6 +1407,14 @@ public class PulsarProperties {
 
 		public void setBatchTimeoutMillis(int batchTimeoutMillis) {
 			this.batchTimeoutMillis = batchTimeoutMillis;
+		}
+
+		public boolean isObservationsEnabled() {
+			return this.observationsEnabled;
+		}
+
+		public void setObservationsEnabled(boolean observationsEnabled) {
+			this.observationsEnabled = observationsEnabled;
 		}
 
 	}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/MethodPulsarListenerEndpoint.java
@@ -146,7 +146,7 @@ public class MethodPulsarListenerEndpoint<V> extends AbstractPulsarListenerEndpo
 		}
 
 		final ConcurrentPulsarMessageListenerContainer<?> containerInstance = (ConcurrentPulsarMessageListenerContainer<?>) container;
-		final PulsarContainerProperties pulsarContainerProperties = containerInstance.getPulsarContainerProperties();
+		final PulsarContainerProperties pulsarContainerProperties = containerInstance.getContainerProperties();
 		final SchemaType schemaType = pulsarContainerProperties.getSchemaType();
 		if (schemaType != SchemaType.NONE) {
 			switch (schemaType) {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
@@ -65,8 +65,6 @@ public class PulsarContainerProperties {
 
 	private AckMode ackMode = AckMode.BATCH;
 
-	private boolean observationEnabled;
-
 	private PulsarListenerObservationConvention observationConvention;
 
 	private Properties pulsarConsumerProperties = new Properties();
@@ -143,18 +141,6 @@ public class PulsarContainerProperties {
 
 	public void setAckMode(AckMode ackMode) {
 		this.ackMode = ackMode;
-	}
-
-	public boolean isObservationEnabled() {
-		return this.observationEnabled;
-	}
-
-	/**
-	 * Set to true to enable observations.
-	 * @param observationEnabled true to enable.
-	 */
-	public void setObservationEnabled(boolean observationEnabled) {
-		this.observationEnabled = observationEnabled;
 	}
 
 	public PulsarListenerObservationConvention getObservationConvention() {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -129,8 +129,8 @@ public class PulsarListenerTests implements PulsarTestContainerSupport {
 		@Bean
 		PulsarListenerContainerFactory<?> pulsarListenerContainerFactory(
 				PulsarConsumerFactory<Object> pulsarConsumerFactory) {
-			final ConcurrentPulsarListenerContainerFactory<?> pulsarListenerContainerFactory = new ConcurrentPulsarListenerContainerFactory<>();
-			pulsarListenerContainerFactory.setPulsarConsumerFactory(pulsarConsumerFactory);
+			final ConcurrentPulsarListenerContainerFactory<?> pulsarListenerContainerFactory = new ConcurrentPulsarListenerContainerFactory<>(
+					pulsarConsumerFactory, new PulsarContainerProperties(), null);
 			return pulsarListenerContainerFactory;
 		}
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/observation/ObservationIntegrationTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/observation/ObservationIntegrationTests.java
@@ -45,6 +45,7 @@ import org.springframework.pulsar.core.PulsarConsumerFactory;
 import org.springframework.pulsar.core.PulsarProducerFactory;
 import org.springframework.pulsar.core.PulsarTemplate;
 import org.springframework.pulsar.core.PulsarTestContainerSupport;
+import org.springframework.pulsar.listener.PulsarContainerProperties;
 
 import io.micrometer.common.KeyValues;
 import io.micrometer.core.tck.MeterRegistryAssert;
@@ -130,10 +131,9 @@ public class ObservationIntegrationTests extends SampleTestRunner implements Pul
 		}
 
 		@Bean
-		public PulsarTemplate<String> pulsarTemplate(PulsarProducerFactory<String> pulsarProducerFactory) {
-			PulsarTemplate<String> template = new PulsarTemplate<>(pulsarProducerFactory);
-			template.setObservationEnabled(true);
-			return template;
+		public PulsarTemplate<String> pulsarTemplate(PulsarProducerFactory<String> pulsarProducerFactory,
+				ObservationRegistry observationRegistry) {
+			return new PulsarTemplate<>(pulsarProducerFactory, null, observationRegistry, null);
 		}
 
 		@Bean
@@ -143,11 +143,9 @@ public class ObservationIntegrationTests extends SampleTestRunner implements Pul
 
 		@Bean
 		PulsarListenerContainerFactory<?> pulsarListenerContainerFactory(
-				PulsarConsumerFactory<Object> pulsarConsumerFactory) {
-			final ConcurrentPulsarListenerContainerFactory<?> pulsarListenerContainerFactory = new ConcurrentPulsarListenerContainerFactory<>();
-			pulsarListenerContainerFactory.setPulsarConsumerFactory(pulsarConsumerFactory);
-			pulsarListenerContainerFactory.getContainerProperties().setObservationEnabled(true);
-			return pulsarListenerContainerFactory;
+				PulsarConsumerFactory<Object> pulsarConsumerFactory, ObservationRegistry observationRegistry) {
+			return new ConcurrentPulsarListenerContainerFactory<>(pulsarConsumerFactory,
+					new PulsarContainerProperties(), observationRegistry);
 		}
 
 		@Bean


### PR DESCRIPTION
Adds auto-configuration of the observation aspects of the listener and template. 

### Points of interest
* I refactored the template and listeners to use immutable constructors for some key pieces to simplify them as well as make them auto-configuration friendly (eg. the auto-config will/not pass in the observation registry when user has disabled the obeservations property).

Resolves #147