### PR TITLE
Add tests to DefaultReactiveMessageConsumerFactoryTests (#185)

### DIFF
--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/reactive/DefaultReactiveMessageConsumerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/reactive/DefaultReactiveMessageConsumerFactoryTests.java
@@ -27,44 +27,79 @@ import org.apache.pulsar.reactive.client.api.MutableReactiveMessageConsumerSpec;
 import org.apache.pulsar.reactive.client.api.ReactiveMessageConsumer;
 import org.apache.pulsar.reactive.client.api.ReactiveMessageConsumerSpec;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link DefaultReactivePulsarConsumerFactory}
  *
  * @author Christophe Bornet
+ * @author Chris Bono
  */
 class DefaultReactiveMessageConsumerFactoryTests {
 
 	private static final Schema<String> SCHEMA = Schema.STRING;
 
-	@Test
-	void createConsumer() {
-		MutableReactiveMessageConsumerSpec spec = new MutableReactiveMessageConsumerSpec();
-		spec.setConsumerName("test-consumer");
-		DefaultReactivePulsarConsumerFactory<String> consumerFactory = new DefaultReactivePulsarConsumerFactory<>(
-				AdaptedReactivePulsarClientFactory.create((PulsarClient) null), spec);
+	@Nested
+	class FactoryCreatedWithoutSpec {
 
-		ReactiveMessageConsumer<String> consumer = consumerFactory.createConsumer(SCHEMA);
+		private DefaultReactivePulsarConsumerFactory<String> consumerFactory = new DefaultReactivePulsarConsumerFactory<>(
+				AdaptedReactivePulsarClientFactory.create((PulsarClient) null), null);
 
-		assertThat(consumer)
-				.extracting("consumerSpec", InstanceOfAssertFactories.type(ReactiveMessageConsumerSpec.class))
-				.extracting(ReactiveMessageConsumerSpec::getConsumerName).isEqualTo("test-consumer");
+		@Test
+		void createConsumer() {
+			ReactiveMessageConsumer<String> consumer = consumerFactory.createConsumer(SCHEMA);
+
+			assertThat(consumer)
+					.extracting("consumerSpec", InstanceOfAssertFactories.type(ReactiveMessageConsumerSpec.class))
+					.isNotNull();
+		}
+
+		@Test
+		void createConsumerWithCustomizer() {
+			ReactiveMessageConsumer<String> consumer = consumerFactory.createConsumer(SCHEMA,
+					Collections.singletonList(builder -> builder.consumerName("new-test-consumer")));
+
+			assertThat(consumer)
+					.extracting("consumerSpec", InstanceOfAssertFactories.type(ReactiveMessageConsumerSpec.class))
+					.extracting(ReactiveMessageConsumerSpec::getConsumerName).isEqualTo("new-test-consumer");
+		}
+
 	}
 
-	@Test
-	void createConsumerWithCustomizer() {
-		MutableReactiveMessageConsumerSpec spec = new MutableReactiveMessageConsumerSpec();
-		spec.setConsumerName("test-consumer");
-		DefaultReactivePulsarConsumerFactory<String> consumerFactory = new DefaultReactivePulsarConsumerFactory<>(
-				AdaptedReactivePulsarClientFactory.create((PulsarClient) null), spec);
+	@Nested
+	class FactoryCreatedWithSpec {
 
-		ReactiveMessageConsumer<String> consumer = consumerFactory.createConsumer(SCHEMA,
-				Collections.singletonList(builder -> builder.consumerName("new-test-consumer")));
+		private DefaultReactivePulsarConsumerFactory<String> consumerFactory;
 
-		assertThat(consumer)
-				.extracting("consumerSpec", InstanceOfAssertFactories.type(ReactiveMessageConsumerSpec.class))
-				.extracting(ReactiveMessageConsumerSpec::getConsumerName).isEqualTo("new-test-consumer");
+		@BeforeEach
+		void createConsumerFactory() {
+			MutableReactiveMessageConsumerSpec spec = new MutableReactiveMessageConsumerSpec();
+			spec.setConsumerName("test-consumer");
+			consumerFactory = new DefaultReactivePulsarConsumerFactory<>(
+					AdaptedReactivePulsarClientFactory.create((PulsarClient) null), spec);
+		}
+
+		@Test
+		void createConsumer() {
+			ReactiveMessageConsumer<String> consumer = consumerFactory.createConsumer(SCHEMA);
+
+			assertThat(consumer)
+					.extracting("consumerSpec", InstanceOfAssertFactories.type(ReactiveMessageConsumerSpec.class))
+					.extracting(ReactiveMessageConsumerSpec::getConsumerName).isEqualTo("test-consumer");
+		}
+
+		@Test
+		void createConsumerWithCustomizer() {
+			ReactiveMessageConsumer<String> consumer = consumerFactory.createConsumer(SCHEMA,
+					Collections.singletonList(builder -> builder.consumerName("new-test-consumer")));
+
+			assertThat(consumer)
+					.extracting("consumerSpec", InstanceOfAssertFactories.type(ReactiveMessageConsumerSpec.class))
+					.extracting(ReactiveMessageConsumerSpec::getConsumerName).isEqualTo("new-test-consumer");
+		}
+
 	}
 
 }


### PR DESCRIPTION
DO NOT MERGE: For discussion only.

@cbornet I was going to add a polish commit to recently merged PR (see [comment](https://github.com/spring-projects-experimental/spring-pulsar/pull/178#discussion_r1008572835)). However, when doing so I figured I wanted to run both of these styles by you before pushing a commit on top of yours w/o your approval / review. 

I wanted to add coverage for the case where the RPCF was created w/ a null spec. It basically doubles the test methods such that we check both `createConsumer()` w/ customizer and w/o customizer on both factories (one created w/ spec and one created w/o spec). 

I did it 2 ways in this proposal - w/ and w/o the use of `@Nested`. Which do you prefer? Or, would a single test just verifying the `<init> w/ null spec` be sufficient? 