### PR TITLE
Use type safe structures to configure the producer

### DIFF
--- a/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
@@ -63,6 +63,29 @@ template.newMessage(msg)
 ----
 ====
 
+This other example shows how to use custom routing when publishing records to partitioned topics.
+Specify your custom `MessageRouter` implementation on the `Producer` builder such as:
+====
+[source, java]
+----
+template.newMessage(msg)
+        .withProducerCustomizer((pb) -> pb.messageRouter(messageRouter))
+        .send();
+----
+====
+
+TIP: Note that, when using a `MessageRouter`, the only valid setting for `spring.pulsar.producer.message-routing-mode` is `custom`.
+
+This other example shows how to add a `ProducerInterceptor` that will intercept and mutate messages received by the producer before being published to the brokers:
+====
+[source, java]
+----
+template.newMessage(msg)
+        .withProducerCustomizer((pb) -> pb.intercept(interceptor))
+        .send();
+----
+====
+
 ===== Schema
 If you use Java primitive types, the framework auto-detects the schema for you, and you need not specify any schema types for publishing the data.
 However, if you use any complex types (such as `JSON`, `AVRO`, `PROTOBUF`, and others), you need to set the proper schema type on the `PulsarTemplate` before invoking any send operations, as the following example shows for JSON:

--- a/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
@@ -63,19 +63,6 @@ template.newMessage(msg)
 ----
 ====
 
-====== Custom routing
-You can use custom routing when publishing records to partitioned topics. To do so, specify your custom `MessageRouter` implementation on the fluent builder:
-====
-[source, java]
-----
-template.newMessage(msg)
-    .withCustomRouter(myCustomRouter)
-    .send();
-----
-====
-
-TIP: Note that, when using a `MessageRouter`, the only valid setting for `spring.pulsar.producer.message-routing-mode` is `custom`.
-
 ===== Schema
 If you use Java primitive types, the framework auto-detects the schema for you, and you need not specify any schema types for publishing the data.
 However, if you use any complex types (such as `JSON`, `AVRO`, `PROTOBUF`, and others), you need to set the proper schema type on the `PulsarTemplate` before invoking any send operations, as the following example shows for JSON:

--- a/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
@@ -58,8 +58,8 @@ For example, the following code shows how to disable batching and enable chunkin
 [source, java]
 ----
 template.newMessage(msg)
-        .withProducerCustomizer((pb) -> pb.enableChunking(true).enableBatching(false))
-        .send();
+    .withProducerCustomizer((pb) -> pb.enableChunking(true).enableBatching(false))
+    .send();
 ----
 ====
 
@@ -69,8 +69,8 @@ Specify your custom `MessageRouter` implementation on the `Producer` builder suc
 [source, java]
 ----
 template.newMessage(msg)
-        .withProducerCustomizer((pb) -> pb.messageRouter(messageRouter))
-        .send();
+    .withProducerCustomizer((pb) -> pb.messageRouter(messageRouter))
+    .send();
 ----
 ====
 
@@ -81,8 +81,8 @@ This other example shows how to add a `ProducerInterceptor` that will intercept 
 [source, java]
 ----
 template.newMessage(msg)
-        .withProducerCustomizer((pb) -> pb.intercept(interceptor))
-        .send();
+    .withProducerCustomizer((pb) -> pb.intercept(interceptor))
+    .send();
 ----
 ====
 

--- a/spring-pulsar-sample-apps/sample-app2/src/main/java/app2/FailoverConsumerApp.java
+++ b/spring-pulsar-sample-apps/sample-app2/src/main/java/app2/FailoverConsumerApp.java
@@ -46,12 +46,12 @@ public class FailoverConsumerApp {
 		String topic = "failover-demo-topic";
 		return args -> {
 			for (int i = 0; i < 10; i++) {
-				pulsarTemplate.newMessage("hello john doe 0 ").withTopic(topic).withCustomRouter(new FooRouter())
-						.sendAsync();
-				pulsarTemplate.newMessage("hello alice doe 1").withTopic(topic).withCustomRouter(new BarRouter())
-						.sendAsync();
-				pulsarTemplate.newMessage("hello buzz doe 2").withTopic(topic).withCustomRouter(new BuzzRouter())
-						.sendAsync();
+				pulsarTemplate.newMessage("hello john doe 0 ").withTopic(topic)
+						.withProducerCustomizer(builder -> builder.messageRouter(new FooRouter())).sendAsync();
+				pulsarTemplate.newMessage("hello alice doe 1")
+						.withProducerCustomizer(builder -> builder.messageRouter(new BarRouter())).sendAsync();
+				pulsarTemplate.newMessage("hello buzz doe 2")
+						.withProducerCustomizer(builder -> builder.messageRouter(new BuzzRouter())).sendAsync();
 				Thread.sleep(1_000);
 			}
 		};

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/CachingPulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/CachingPulsarProducerFactory.java
@@ -17,21 +17,22 @@
 package org.springframework.pulsar.core;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.LogFactory;
-import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 import org.apache.pulsar.common.protocol.schema.SchemaHash;
 
 import org.springframework.aop.framework.AopProxyUtils;
@@ -60,6 +61,7 @@ import com.github.benmanes.caffeine.cache.Scheduler;
  * @param <T> producer type.
  * @author Chris Bono
  * @author Alexander Preuß
+ * @author Christophe Bornet
  */
 public class CachingPulsarProducerFactory<T> extends DefaultPulsarProducerFactory<T> implements DisposableBean {
 
@@ -91,22 +93,19 @@ public class CachingPulsarProducerFactory<T> extends DefaultPulsarProducerFactor
 	}
 
 	@Override
-	protected Producer<T> doCreateProducer(@Nullable String topic, Schema<T> schema,
-			@Nullable MessageRouter messageRouter, @Nullable List<ProducerInterceptor> producerInterceptors,
-			@Nullable List<ProducerBuilderCustomizer<T>> producerBuilderCustomizers) {
+	protected Producer<T> doCreateProducer(Schema<T> schema, @Nullable String topic,
+			@Nullable Collection<String> encryptionKeys, @Nullable List<ProducerBuilderCustomizer<T>> customizers) {
 		final String topicName = ProducerUtils.resolveTopicName(topic, this);
-		ProducerCacheKey<T> producerCacheKey = new ProducerCacheKey<>(schema, topicName, messageRouter,
-				producerInterceptors);
-		return this.producerCache.get(producerCacheKey, (st) -> createCacheableProducer(st.topic, st.schema, st.router,
-				st.interceptors, producerBuilderCustomizers));
+		ProducerCacheKey<T> producerCacheKey = new ProducerCacheKey<>(schema, topicName,
+				encryptionKeys == null ? null : new HashSet<>(encryptionKeys), customizers);
+		return this.producerCache.get(producerCacheKey,
+				(st) -> createCacheableProducer(st.schema, st.topic, st.encryptionKeys, customizers));
 	}
 
-	private Producer<T> createCacheableProducer(String topic, Schema<T> schema, @Nullable MessageRouter messageRouter,
-			@Nullable List<ProducerInterceptor> producerInterceptors,
-			@Nullable List<ProducerBuilderCustomizer<T>> producerBuilderCustomizers) {
+	private Producer<T> createCacheableProducer(Schema<T> schema, String topic,
+			@Nullable Collection<String> encryptionKeys, @Nullable List<ProducerBuilderCustomizer<T>> customizers) {
 		try {
-			Producer<T> producer = super.doCreateProducer(topic, schema, messageRouter, producerInterceptors,
-					producerBuilderCustomizers);
+			Producer<T> producer = super.doCreateProducer(schema, topic, encryptionKeys, customizers);
 			return wrapProducerWithCloseCallback(producer,
 					(p) -> this.logger
 							.trace(() -> String.format("Client closed producer %s but will skip actual closing",
@@ -171,28 +170,28 @@ public class CachingPulsarProducerFactory<T> extends DefaultPulsarProducerFactor
 		private final String topic;
 
 		@Nullable
-		private final MessageRouter router;
+		private final Set<String> encryptionKeys;
 
 		@Nullable
-		private final List<ProducerInterceptor> interceptors;
+		private final List<ProducerBuilderCustomizer<T>> customizers;
 
 		/**
 		 * Constructs an instance.
 		 * @param schema the schema the producer is configured to use
 		 * @param topic the topic the producer is configured to send to
-		 * @param router the custom message router the producer is configured to use
-		 * @param interceptors the list of producer interceptors the producer is
-		 * configured to use
+		 * @param encryptionKeys the encryption keys used by the producer
+		 * @param customizers the list of producer customizers the producer is configured
+		 * to use
 		 */
-		ProducerCacheKey(Schema<T> schema, String topic, @Nullable MessageRouter router,
-				@Nullable List<ProducerInterceptor> interceptors) {
+		ProducerCacheKey(Schema<T> schema, String topic, @Nullable Set<String> encryptionKeys,
+				@Nullable List<ProducerBuilderCustomizer<T>> customizers) {
 			Assert.notNull(schema, () -> "'schema' must be non-null");
 			Assert.notNull(topic, () -> "'topic' must be non-null");
 			this.schema = schema;
 			this.schemaHash = SchemaHash.of(this.schema);
 			this.topic = topic;
-			this.router = router;
-			this.interceptors = interceptors;
+			this.encryptionKeys = encryptionKeys;
+			this.customizers = customizers;
 		}
 
 		@Override
@@ -205,13 +204,14 @@ public class CachingPulsarProducerFactory<T> extends DefaultPulsarProducerFactor
 			}
 			ProducerCacheKey<?> that = (ProducerCacheKey<?>) o;
 			return this.topic.equals(that.topic) && this.schemaHash.equals(that.schemaHash)
-					&& Objects.equals(this.router, that.router) && Objects.equals(this.interceptors, that.interceptors);
+					&& Objects.equals(this.encryptionKeys, that.encryptionKeys)
+					&& Objects.equals(this.customizers, that.customizers);
 		}
 
 		@Override
 		public int hashCode() {
-			return this.topic.hashCode() + this.schemaHash.hashCode() + Objects.hashCode(this.router)
-					+ Objects.hashCode(this.interceptors);
+			return this.topic.hashCode() + this.schemaHash.hashCode() + Objects.hashCode(this.encryptionKeys)
+					+ Objects.hashCode(this.customizers);
 		}
 
 	}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
@@ -98,6 +98,7 @@ public class DefaultPulsarProducerFactory<T> implements PulsarProducerFactory<T>
 
 		Map<String, Object> config = new HashMap<>(this.producerConfig);
 
+		// Replace default keys - workaround as they can't be replaced through the builder
 		if (encryptionKeys != null) {
 			config.put("encryptionKeys", encryptionKeys);
 		}
@@ -118,15 +119,12 @@ public class DefaultPulsarProducerFactory<T> implements PulsarProducerFactory<T>
 	private static <T> void loadConf(ProducerBuilder<T> producerBuilder, Map<String, Object> config) {
 		producerBuilder.loadConf(config);
 
-		// Workaround because encryptionKeys are not loaded by loadConf and can't be
-		// replaced through the builder
+		// Set fields that are not loaded by loadConf
 		if (config.containsKey("encryptionKeys")) {
 			@SuppressWarnings("unchecked")
 			Collection<String> keys = (Collection<String>) config.get("encryptionKeys");
 			keys.forEach(producerBuilder::addEncryptionKey);
 		}
-
-		// Set non-serializable fields that not loaded by loadConf
 		if (config.containsKey("customMessageRouter")) {
 			producerBuilder.messageRouter((MessageRouter) config.get("customMessageRouter"));
 		}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarProducerFactory.java
@@ -16,18 +16,21 @@
 
 package org.springframework.pulsar.core;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.logging.LogFactory;
+import org.apache.pulsar.client.api.BatcherBuilder;
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 
 import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
@@ -40,76 +43,88 @@ import org.springframework.util.CollectionUtils;
  * @author Soby Chacko
  * @author Chris Bono
  * @author Alexander Preuß
+ * @author Christophe Bornet
  */
 public class DefaultPulsarProducerFactory<T> implements PulsarProducerFactory<T> {
 
 	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(this.getClass()));
 
-	private final Map<String, Object> producerConfig = new HashMap<>();
+	private final Map<String, Object> producerConfig;
 
 	private final PulsarClient pulsarClient;
 
 	public DefaultPulsarProducerFactory(PulsarClient pulsarClient, Map<String, Object> config) {
 		this.pulsarClient = pulsarClient;
-		if (!CollectionUtils.isEmpty(config)) {
-			this.producerConfig.putAll(config);
-		}
+		this.producerConfig = Collections.unmodifiableMap(config);
 	}
 
 	@Override
-	public Producer<T> createProducer(@Nullable String topic, Schema<T> schema) throws PulsarClientException {
-		return doCreateProducer(topic, schema, null, null, null);
+	public Producer<T> createProducer(Schema<T> schema) throws PulsarClientException {
+		return doCreateProducer(schema, null, null, null);
 	}
 
 	@Override
-	public Producer<T> createProducer(@Nullable String topic, Schema<T> schema, @Nullable MessageRouter messageRouter)
+	public Producer<T> createProducer(Schema<T> schema, @Nullable String topic) throws PulsarClientException {
+		return doCreateProducer(schema, topic, null, null);
+	}
+
+	@Override
+	public Producer<T> createProducer(Schema<T> schema, @Nullable String topic,
+			@Nullable Collection<String> encryptionKeys, @Nullable List<ProducerBuilderCustomizer<T>> customizers)
 			throws PulsarClientException {
-		return doCreateProducer(topic, schema, messageRouter, null, null);
-	}
-
-	@Override
-	public Producer<T> createProducer(@Nullable String topic, Schema<T> schema, @Nullable MessageRouter messageRouter,
-			@Nullable List<ProducerInterceptor> producerInterceptors) throws PulsarClientException {
-		return doCreateProducer(topic, schema, messageRouter, producerInterceptors, null);
-	}
-
-	@Override
-	public Producer<T> createProducer(@Nullable String topic, Schema<T> schema, @Nullable MessageRouter messageRouter,
-			@Nullable List<ProducerInterceptor> producerInterceptors,
-			@Nullable List<ProducerBuilderCustomizer<T>> producerBuilderCustomizers) throws PulsarClientException {
-		return doCreateProducer(topic, schema, messageRouter, producerInterceptors, producerBuilderCustomizers);
+		return doCreateProducer(schema, topic, encryptionKeys, customizers);
 	}
 
 	/**
 	 * Create the actual producer.
+	 * @param schema the schema of the messages to be sent
 	 * @param topic the topic the producer will send messages to or {@code null} to use
 	 * the default topic
-	 * @param schema the schema of the messages to be sent
-	 * @param messageRouter the optional message router to use
-	 * @param producerInterceptors the optional producer interceptors to use
-	 * @param producerBuilderCustomizers the optional list of customizers to apply to the
-	 * producer builder
+	 * @param encryptionKeys the encryption keys used by the producer or {@code null} to
+	 * use the default encryption keys
+	 * @param customizers the optional list of customizers to apply to the producer
+	 * builder
 	 * @return the created producer
 	 * @throws PulsarClientException if any error occurs
 	 */
-	protected Producer<T> doCreateProducer(@Nullable String topic, Schema<T> schema,
-			@Nullable MessageRouter messageRouter, @Nullable List<ProducerInterceptor> producerInterceptors,
-			@Nullable List<ProducerBuilderCustomizer<T>> producerBuilderCustomizers) throws PulsarClientException {
-		final String resolvedTopic = ProducerUtils.resolveTopicName(topic, this);
+	@SuppressWarnings("unchecked")
+	protected Producer<T> doCreateProducer(Schema<T> schema, @Nullable String topic,
+			@Nullable Collection<String> encryptionKeys, @Nullable List<ProducerBuilderCustomizer<T>> customizers)
+			throws PulsarClientException {
+		String resolvedTopic = ProducerUtils.resolveTopicName(topic, this);
 		this.logger.trace(() -> String.format("Creating producer for '%s' topic", resolvedTopic));
-		final ProducerBuilder<T> producerBuilder = this.pulsarClient.newProducer(schema);
-		if (!CollectionUtils.isEmpty(this.producerConfig)) {
-			producerBuilder.loadConf(this.producerConfig);
+		ProducerBuilder<T> producerBuilder = this.pulsarClient.newProducer(schema);
+
+		Map<String, Object> config = new HashMap<>(this.producerConfig);
+
+		if (encryptionKeys != null) {
+			config.put("encryptionKeys", encryptionKeys);
 		}
+
+		producerBuilder.loadConf(config);
+
+		// Workaround because encryptionKeys are not loaded by loadConf and can't be
+		// replaced through the builder
+		if (config.containsKey("encryptionKeys")) {
+			Collection<String> keys = (Collection<String>) config.get("encryptionKeys");
+			keys.forEach(producerBuilder::addEncryptionKey);
+		}
+
 		producerBuilder.topic(resolvedTopic);
-		if (messageRouter != null) {
-			producerBuilder.messageRouter(messageRouter);
+
+		// Set non-serializable fields that not loaded by loadConf
+		if (config.containsKey("customMessageRouter")) {
+			producerBuilder.messageRouter((MessageRouter) config.get("customMessageRouter"));
 		}
-		if (!CollectionUtils.isEmpty(producerInterceptors)) {
-			producerBuilder.intercept(producerInterceptors.toArray(new ProducerInterceptor[0]));
+		if (config.containsKey("batcherBuilder")) {
+			producerBuilder.batcherBuilder((BatcherBuilder) config.get("batcherBuilder"));
 		}
-		if (!CollectionUtils.isEmpty(producerBuilderCustomizers)) {
-			producerBuilderCustomizers.forEach((c) -> c.customize(producerBuilder));
+		if (config.containsKey("cryptoKeyReader")) {
+			producerBuilder.cryptoKeyReader((CryptoKeyReader) config.get("cryptoKeyReader"));
+		}
+
+		if (!CollectionUtils.isEmpty(customizers)) {
+			customizers.forEach((c) -> c.customize(producerBuilder));
 		}
 		return producerBuilder.create();
 	}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarOperations.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarOperations.java
@@ -16,10 +16,10 @@
 
 package org.springframework.pulsar.core;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.PulsarClientException;
 
 import org.springframework.lang.Nullable;
@@ -92,18 +92,18 @@ public interface PulsarOperations<T> {
 		SendMessageBuilder<T> withTopic(String topic);
 
 		/**
+		 * Specify the encryption keys to use.
+		 * @param encryptionKeys the encryption keys
+		 * @return the current builder with the encryption keys specified
+		 */
+		SendMessageBuilder<T> withEncryptionKeys(Collection<String> encryptionKeys);
+
+		/**
 		 * Specifies the message customizer to use to further configure the message.
 		 * @param messageCustomizer the message customizer
 		 * @return the current builder with the message customizer specified
 		 */
 		SendMessageBuilder<T> withMessageCustomizer(TypedMessageBuilderCustomizer<T> messageCustomizer);
-
-		/**
-		 * Specifies the custom message router to use when sending the message.
-		 * @param messageRouter the custom message router
-		 * @return the current builder with the custom message router specified
-		 */
-		SendMessageBuilder<T> withCustomRouter(MessageRouter messageRouter);
 
 		/**
 		 * Specifies the customizer to use to further configure the producer builder.

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarProducerFactory.java
@@ -16,14 +16,13 @@
 
 package org.springframework.pulsar.core;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 
 import org.springframework.lang.Nullable;
 
@@ -34,59 +33,42 @@ import org.springframework.lang.Nullable;
  * @author Soby Chacko
  * @author Chris Bono
  * @author Alexander Preuß
+ * @author Christophe Bornet
  */
 public interface PulsarProducerFactory<T> {
 
 	/**
 	 * Create a producer.
-	 * @param topic the topic the producer will send messages to or {@code null} to use
-	 * the default topic
 	 * @param schema the schema of the messages to be sent
 	 * @return the producer
 	 * @throws PulsarClientException if any error occurs
 	 */
-	Producer<T> createProducer(String topic, Schema<T> schema) throws PulsarClientException;
+	Producer<T> createProducer(Schema<T> schema) throws PulsarClientException;
 
 	/**
 	 * Create a producer.
 	 * @param topic the topic the producer will send messages to or {@code null} to use
 	 * the default topic
 	 * @param schema the schema of the messages to be sent
-	 * @param messageRouter the optional message router to use
 	 * @return the producer
 	 * @throws PulsarClientException if any error occurs
 	 */
-	Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter)
-			throws PulsarClientException;
+	Producer<T> createProducer(Schema<T> schema, @Nullable String topic) throws PulsarClientException;
 
 	/**
 	 * Create a producer.
+	 * @param schema the schema of the messages to be sent
 	 * @param topic the topic the producer will send messages to or {@code null} to use
 	 * the default topic
-	 * @param schema the schema of the messages to be sent
-	 * @param messageRouter the optional message router to use
-	 * @param producerInterceptors the optional producer interceptors to use
+	 * @param encryptionKeys the encryption keys used by the producer or {@code null} to
+	 * use the default encryption keys
+	 * @param customizers the optional list of customizers to apply to the producer
+	 * builder
 	 * @return the producer
 	 * @throws PulsarClientException if any error occurs
 	 */
-	Producer<T> createProducer(String topic, Schema<T> schema, MessageRouter messageRouter,
-			List<ProducerInterceptor> producerInterceptors) throws PulsarClientException;
-
-	/**
-	 * Create a producer.
-	 * @param topic the topic the producer will send messages to or {@code null} to use
-	 * the default topic
-	 * @param schema the schema of the messages to be sent
-	 * @param messageRouter the optional message router to use
-	 * @param producerInterceptors the optional producer interceptors to use
-	 * @param producerBuilderCustomizers the optional list of customizers to apply to the
-	 * producer builder
-	 * @return the producer
-	 * @throws PulsarClientException if any error occurs
-	 */
-	Producer<T> createProducer(@Nullable String topic, Schema<T> schema, @Nullable MessageRouter messageRouter,
-			@Nullable List<ProducerInterceptor> producerInterceptors,
-			@Nullable List<ProducerBuilderCustomizer<T>> producerBuilderCustomizers) throws PulsarClientException;
+	Producer<T> createProducer(Schema<T> schema, @Nullable String topic, @Nullable Collection<String> encryptionKeys,
+			@Nullable List<ProducerBuilderCustomizer<T>> customizers) throws PulsarClientException;
 
 	/**
 	 * Return a map of configuration options to use when creating producers.

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarProducerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarProducerFactory.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 
@@ -47,9 +48,9 @@ public interface PulsarProducerFactory<T> {
 
 	/**
 	 * Create a producer.
+	 * @param schema the schema of the messages to be sent
 	 * @param topic the topic the producer will send messages to or {@code null} to use
 	 * the default topic
-	 * @param schema the schema of the messages to be sent
 	 * @return the producer
 	 * @throws PulsarClientException if any error occurs
 	 */
@@ -60,8 +61,10 @@ public interface PulsarProducerFactory<T> {
 	 * @param schema the schema of the messages to be sent
 	 * @param topic the topic the producer will send messages to or {@code null} to use
 	 * the default topic
-	 * @param encryptionKeys the encryption keys used by the producer or {@code null} to
-	 * use the default encryption keys
+	 * @param encryptionKeys the encryption keys used by the producer, replacing the
+	 * default encryption keys or {@code null} to use the default encryption keys. Beware
+	 * that {@link ProducerBuilder} only has {@link ProducerBuilder#addEncryptionKey} and
+	 * doesn't have methods to replace the encryption keys.
 	 * @param customizers the optional list of customizers to apply to the producer
 	 * builder
 	 * @return the producer

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
@@ -35,10 +35,10 @@ import org.springframework.pulsar.observation.DefaultPulsarTemplateObservationCo
 import org.springframework.pulsar.observation.PulsarMessageSenderContext;
 import org.springframework.pulsar.observation.PulsarTemplateObservation;
 import org.springframework.pulsar.observation.PulsarTemplateObservationConvention;
+import org.springframework.util.CollectionUtils;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
-import org.springframework.util.CollectionUtils;
 
 /**
  * A thread-safe template for executing high-level Pulsar operations.

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarTemplate.java
@@ -16,12 +16,12 @@
 
 package org.springframework.pulsar.core;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
@@ -46,6 +46,7 @@ import io.micrometer.observation.ObservationRegistry;
  * @author Soby Chacko
  * @author Chris Bono
  * @author Alexander Preuß
+ * @author Christophe Bornet
  */
 public class PulsarTemplate<T> implements PulsarOperations<T>, BeanNameAware {
 
@@ -141,12 +142,11 @@ public class PulsarTemplate<T> implements PulsarOperations<T>, BeanNameAware {
 		this.schema = schema;
 	}
 
-	private MessageId doSend(@Nullable String topic, T message,
+	private MessageId doSend(@Nullable String topic, T message, @Nullable Collection<String> encryptionKeys,
 			@Nullable TypedMessageBuilderCustomizer<T> typedMessageBuilderCustomizer,
-			@Nullable MessageRouter messageRouter, @Nullable ProducerBuilderCustomizer<T> producerCustomizer)
-			throws PulsarClientException {
+			@Nullable ProducerBuilderCustomizer<T> producerCustomizer) throws PulsarClientException {
 		try {
-			return doSendAsync(topic, message, typedMessageBuilderCustomizer, messageRouter, producerCustomizer).get();
+			return doSendAsync(topic, message, encryptionKeys, typedMessageBuilderCustomizer, producerCustomizer).get();
 		}
 		catch (Exception ex) {
 			throw PulsarClientException.unwrap(ex);
@@ -154,9 +154,9 @@ public class PulsarTemplate<T> implements PulsarOperations<T>, BeanNameAware {
 	}
 
 	private CompletableFuture<MessageId> doSendAsync(@Nullable String topic, T message,
+			@Nullable Collection<String> encryptionKeys,
 			@Nullable TypedMessageBuilderCustomizer<T> typedMessageBuilderCustomizer,
-			@Nullable MessageRouter messageRouter, @Nullable ProducerBuilderCustomizer<T> producerCustomizer)
-			throws PulsarClientException {
+			@Nullable ProducerBuilderCustomizer<T> producerCustomizer) throws PulsarClientException {
 		final String topicName = ProducerUtils.resolveTopicName(topic, this.producerFactory);
 		this.logger.trace(() -> String.format("Sending msg to '%s' topic", topicName));
 
@@ -164,7 +164,7 @@ public class PulsarTemplate<T> implements PulsarOperations<T>, BeanNameAware {
 		Observation observation = newObservation(senderContext);
 		try {
 			observation.start();
-			final Producer<T> producer = prepareProducerForSend(topic, message, messageRouter, producerCustomizer);
+			final Producer<T> producer = prepareProducerForSend(topic, message, encryptionKeys, producerCustomizer);
 			TypedMessageBuilder<T> messageBuilder = producer.newMessage().value(message);
 			if (typedMessageBuilderCustomizer != null) {
 				typedMessageBuilderCustomizer.customize(messageBuilder);
@@ -200,11 +200,18 @@ public class PulsarTemplate<T> implements PulsarOperations<T>, BeanNameAware {
 				DefaultPulsarTemplateObservationConvention.INSTANCE, () -> senderContext, this.observationRegistry);
 	}
 
-	private Producer<T> prepareProducerForSend(@Nullable String topic, T message, @Nullable MessageRouter messageRouter,
-			@Nullable ProducerBuilderCustomizer<T> producerCustomizer) throws PulsarClientException {
+	private Producer<T> prepareProducerForSend(@Nullable String topic, T message,
+			@Nullable Collection<String> encryptionKeys, @Nullable ProducerBuilderCustomizer<T> producerCustomizer)
+			throws PulsarClientException {
 		Schema<T> schema = this.schema != null ? this.schema : SchemaUtils.getSchema(message);
-		return this.producerFactory.createProducer(topic, schema, messageRouter, this.interceptors,
-				producerCustomizer == null ? Collections.emptyList() : Collections.singletonList(producerCustomizer));
+		List<ProducerBuilderCustomizer<T>> customizers = new ArrayList<>();
+		if (this.interceptors != null) {
+			customizers.add(builder -> builder.intercept(this.interceptors.toArray(new ProducerInterceptor[0])));
+		}
+		if (producerCustomizer != null) {
+			customizers.add(producerCustomizer);
+		}
+		return this.producerFactory.createProducer(schema, topic, encryptionKeys, customizers);
 	}
 
 	public static class SendMessageBuilderImpl<T> implements SendMessageBuilder<T> {
@@ -217,10 +224,10 @@ public class PulsarTemplate<T> implements PulsarOperations<T>, BeanNameAware {
 		private String topic;
 
 		@Nullable
-		private TypedMessageBuilderCustomizer<T> messageCustomizer;
+		private Collection<String> encryptionKeys;
 
 		@Nullable
-		private MessageRouter messageRouter;
+		private TypedMessageBuilderCustomizer<T> messageCustomizer;
 
 		@Nullable
 		private ProducerBuilderCustomizer<T> producerCustomizer;
@@ -237,14 +244,14 @@ public class PulsarTemplate<T> implements PulsarOperations<T>, BeanNameAware {
 		}
 
 		@Override
-		public SendMessageBuilder<T> withMessageCustomizer(TypedMessageBuilderCustomizer<T> messageCustomizer) {
-			this.messageCustomizer = messageCustomizer;
+		public SendMessageBuilder<T> withEncryptionKeys(Collection<String> encryptionKeys) {
+			this.encryptionKeys = encryptionKeys;
 			return this;
 		}
 
 		@Override
-		public SendMessageBuilder<T> withCustomRouter(MessageRouter messageRouter) {
-			this.messageRouter = messageRouter;
+		public SendMessageBuilder<T> withMessageCustomizer(TypedMessageBuilderCustomizer<T> messageCustomizer) {
+			this.messageCustomizer = messageCustomizer;
 			return this;
 		}
 
@@ -256,13 +263,13 @@ public class PulsarTemplate<T> implements PulsarOperations<T>, BeanNameAware {
 
 		@Override
 		public MessageId send() throws PulsarClientException {
-			return this.template.doSend(this.topic, this.message, this.messageCustomizer, this.messageRouter,
+			return this.template.doSend(this.topic, this.message, this.encryptionKeys, this.messageCustomizer,
 					this.producerCustomizer);
 		}
 
 		@Override
 		public CompletableFuture<MessageId> sendAsync() throws PulsarClientException {
-			return this.template.doSendAsync(this.topic, this.message, this.messageCustomizer, this.messageRouter,
+			return this.template.doSendAsync(this.topic, this.message, this.encryptionKeys, this.messageCustomizer,
 					this.producerCustomizer);
 		}
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
@@ -29,14 +29,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
-import org.apache.pulsar.client.api.MessageRouter;
 import org.apache.pulsar.client.api.Producer;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 import org.apache.pulsar.client.impl.schema.StringSchema;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -60,6 +59,7 @@ import com.github.benmanes.caffeine.cache.Cache;
  *
  * @author Chris Bono
  * @author Alexander Preuß
+ * @author Christophe Bornet
  */
 class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 
@@ -80,9 +80,9 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient, Collections.emptyMap());
 		ProducerCacheKey<String> cacheKey = new ProducerCacheKey<>(schema, "topic1", null, null);
 
-		Producer<String> producer1 = producerFactory.createProducer("topic1", schema);
-		Producer<String> producer2 = producerFactory.createProducer("topic1", new StringSchema());
-		Producer<String> producer3 = producerFactory.createProducer("topic1", new StringSchema());
+		Producer<String> producer1 = producerFactory.createProducer(schema, "topic1");
+		Producer<String> producer2 = producerFactory.createProducer(new StringSchema(), "topic1");
+		Producer<String> producer3 = producerFactory.createProducer(new StringSchema(), "topic1");
 		assertThat(producer1).isSameAs(producer2).isSameAs(producer3);
 
 		Cache<ProducerCacheKey<String>, Producer<String>> producerCache = getAssertedProducerCache(producerFactory,
@@ -95,7 +95,7 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 	void cachedProducerIsCloseSafeProxy() throws PulsarClientException {
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient, Collections.emptyMap());
 
-		Producer<String> proxyProducer = producerFactory.createProducer("topic1", schema);
+		Producer<String> proxyProducer = producerFactory.createProducer(schema, "topic1");
 		Producer<String> actualProducer = actualProducerFrom(proxyProducer);
 
 		assertThat(actualProducer.isConnected()).isTrue();
@@ -106,66 +106,67 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	void createProducerWithMatrixOfCacheKeys() throws PulsarClientException {
 		String topic1 = "topic1";
 		String topic2 = "topic2";
 		Schema<String> schema1 = new StringSchema();
 		Schema<String> schema2 = new StringSchema();
-		MessageRouter router1 = mock(MessageRouter.class);
-		MessageRouter router2 = mock(MessageRouter.class);
-		List<ProducerInterceptor> interceptors1 = List.of(mock(ProducerInterceptor.class));
-		List<ProducerInterceptor> interceptors2 = List.of(mock(ProducerInterceptor.class));
+		List<ProducerBuilderCustomizer<String>> customizers1 = List.of(mock(ProducerBuilderCustomizer.class));
+		List<ProducerBuilderCustomizer<String>> customizers2 = List.of(mock(ProducerBuilderCustomizer.class));
+		Set<String> encryptionKeys1 = Set.of("key1");
+		Set<String> encryptionKeys2 = Set.of("key2");
 
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient, Collections.emptyMap());
 
 		// ask for the same 21 unique combos 3x - should end up w/ only 21 entries in
 		// cache
 		for (int i = 0; i < 3; i++) {
-			producerFactory.createProducer(topic1, schema1);
-			producerFactory.createProducer(topic1, schema1, router1);
-			producerFactory.createProducer(topic1, schema1, router2);
-			producerFactory.createProducer(topic1, schema1, router1, interceptors1);
-			producerFactory.createProducer(topic1, schema1, router1, interceptors2);
-			producerFactory.createProducer(topic1, schema1, router2, interceptors1);
-			producerFactory.createProducer(topic1, schema1, router2, interceptors2);
-			producerFactory.createProducer(topic1, schema2);
-			producerFactory.createProducer(topic1, schema2, router1);
-			producerFactory.createProducer(topic1, schema2, router2);
-			producerFactory.createProducer(topic1, schema2, router1, interceptors1);
-			producerFactory.createProducer(topic1, schema2, router1, interceptors2);
-			producerFactory.createProducer(topic1, schema2, router2, interceptors1);
-			producerFactory.createProducer(topic1, schema2, router2, interceptors2);
-			producerFactory.createProducer(topic2, schema1);
-			producerFactory.createProducer(topic2, schema1, router1);
-			producerFactory.createProducer(topic2, schema1, router2);
-			producerFactory.createProducer(topic2, schema1, router1, interceptors1);
-			producerFactory.createProducer(topic2, schema1, router1, interceptors2);
-			producerFactory.createProducer(topic2, schema1, router2, interceptors1);
-			producerFactory.createProducer(topic2, schema1, router2, interceptors2);
+			producerFactory.createProducer(schema1, topic1);
+			producerFactory.createProducer(schema1, topic1, encryptionKeys1, null);
+			producerFactory.createProducer(schema1, topic1, encryptionKeys2, null);
+			producerFactory.createProducer(schema1, topic1, encryptionKeys1, customizers1);
+			producerFactory.createProducer(schema1, topic1, encryptionKeys1, customizers2);
+			producerFactory.createProducer(schema1, topic1, encryptionKeys2, customizers1);
+			producerFactory.createProducer(schema1, topic1, encryptionKeys2, customizers2);
+			producerFactory.createProducer(schema2, topic1);
+			producerFactory.createProducer(schema2, topic1, encryptionKeys1, null);
+			producerFactory.createProducer(schema2, topic1, encryptionKeys2, null);
+			producerFactory.createProducer(schema2, topic1, encryptionKeys1, customizers1);
+			producerFactory.createProducer(schema2, topic1, encryptionKeys1, customizers2);
+			producerFactory.createProducer(schema2, topic1, encryptionKeys2, customizers1);
+			producerFactory.createProducer(schema2, topic1, encryptionKeys2, customizers2);
+			producerFactory.createProducer(schema1, topic2);
+			producerFactory.createProducer(schema1, topic2, encryptionKeys1, null);
+			producerFactory.createProducer(schema1, topic2, encryptionKeys2, null);
+			producerFactory.createProducer(schema1, topic2, encryptionKeys1, customizers1);
+			producerFactory.createProducer(schema1, topic2, encryptionKeys1, customizers2);
+			producerFactory.createProducer(schema1, topic2, encryptionKeys2, customizers1);
+			producerFactory.createProducer(schema1, topic2, encryptionKeys2, customizers2);
 		}
 
 		List<ProducerCacheKey<String>> expectedCacheKeys = new ArrayList<>();
 		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, null, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router1, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router1, interceptors1));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router1, interceptors2));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router2, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router2, interceptors1));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, router2, interceptors2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, encryptionKeys1, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, encryptionKeys1, customizers1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, encryptionKeys1, customizers2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, encryptionKeys2, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, encryptionKeys2, customizers1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic1, encryptionKeys2, customizers2));
 		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, null, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router1, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router1, interceptors1));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router1, interceptors2));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router2, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router2, interceptors1));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, router2, interceptors2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, encryptionKeys1, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, encryptionKeys1, customizers1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, encryptionKeys1, customizers2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, encryptionKeys2, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, encryptionKeys2, customizers1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema2, topic1, encryptionKeys2, customizers2));
 		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, null, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router1, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router1, interceptors1));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router1, interceptors2));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router2, null));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router2, interceptors1));
-		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, router2, interceptors2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, encryptionKeys1, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, encryptionKeys1, customizers1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, encryptionKeys1, customizers2));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, encryptionKeys2, null));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, encryptionKeys2, customizers1));
+		expectedCacheKeys.add(new ProducerCacheKey<>(schema1, topic2, encryptionKeys2, customizers2));
 
 		getAssertedProducerCache(producerFactory, expectedCacheKeys);
 	}
@@ -176,8 +177,8 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 		ProducerCacheKey<String> cacheKey1 = new ProducerCacheKey<>(schema, "topic1", null, null);
 		ProducerCacheKey<String> cacheKey2 = new ProducerCacheKey<>(schema, "topic2", null, null);
 
-		Producer<String> actualProducer1 = actualProducerFrom(producerFactory.createProducer("topic1", schema));
-		Producer<String> actualProducer2 = actualProducerFrom(producerFactory.createProducer("topic2", schema));
+		Producer<String> actualProducer1 = actualProducerFrom(producerFactory.createProducer(schema, "topic1"));
+		Producer<String> actualProducer2 = actualProducerFrom(producerFactory.createProducer(schema, "topic2"));
 
 		Cache<ProducerCacheKey<String>, Producer<String>> producerCache = getAssertedProducerCache(producerFactory,
 				Arrays.asList(cacheKey1, cacheKey2));
@@ -195,7 +196,7 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 				Collections.emptyMap(), Duration.ofSeconds(3L), 10L, 2);
 		ProducerCacheKey<String> cacheKey = new ProducerCacheKey<>(schema, "topic1", null, null);
 
-		Producer<String> actualProducer = actualProducerFrom(producerFactory.createProducer("topic1", schema));
+		Producer<String> actualProducer = actualProducerFrom(producerFactory.createProducer(schema, "topic1"));
 
 		Cache<ProducerCacheKey<String>, Producer<String>> producerCache = getAssertedProducerCache(producerFactory,
 				Collections.singletonList(cacheKey));
@@ -210,16 +211,16 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 		pulsarClient = spy(pulsarClient);
 		when(this.pulsarClient.newProducer(schema)).thenThrow(new RuntimeException("5150"));
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient, Collections.emptyMap());
-		assertThatThrownBy(() -> producerFactory.createProducer("topic1", schema)).isInstanceOf(RuntimeException.class)
+		assertThatThrownBy(() -> producerFactory.createProducer(schema, "topic1")).isInstanceOf(RuntimeException.class)
 				.hasMessage("5150");
 		getAssertedProducerCache(producerFactory, Collections.emptyList());
 	}
 
 	@Override
-	protected void assertProducerHasTopicSchemaAndRouter(Producer<String> producer, String topic, Schema<String> schema,
-			MessageRouter router, List<ProducerInterceptor> producerInterceptors) {
-		super.assertProducerHasTopicSchemaAndRouter(actualProducerFrom(producer), topic, schema, router,
-				producerInterceptors);
+	protected void assertProducerHasTopicSchemaAndEncryptionKeys(Producer<String> producer, String topic,
+			Schema<String> schema, Set<String> encryptionKeys) {
+		super.assertProducerHasTopicSchemaAndEncryptionKeys(actualProducerFrom(producer), topic, schema,
+				encryptionKeys);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -277,51 +278,59 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 			}
 		}
 
+		@SuppressWarnings("unchecked")
 		static Stream<Arguments> equalsAndHashCodeTestProvider() {
-			MessageRouter router1 = mock(MessageRouter.class);
-			List<ProducerInterceptor> interceptors1 = Collections.singletonList(mock(ProducerInterceptor.class));
-			ProducerCacheKey<String> key1 = new ProducerCacheKey<>(Schema.STRING, "topic1", router1, interceptors1);
-			return Stream.of(arguments(Named.of("differentClass", key1), "someStrangeObject", false),
-					arguments(Named.of("null", key1), null, false),
-					arguments(Named.of("sameInstance", key1), key1, true),
-					arguments(
-							Named.of("sameSchemaSameTopicSameNullRouterSameNullInterceptors",
+			Set<String> encryptionKeys1 = Set.of("key1");
+			List<ProducerBuilderCustomizer<String>> customizers1 = Collections
+					.singletonList(mock(ProducerBuilderCustomizer.class));
+			ProducerCacheKey<String> key1 = new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1,
+					customizers1);
+			return Stream
+					.of(arguments(Named.of("differentClass", key1), "someStrangeObject", false),
+							arguments(Named.of("null", key1), null, false),
+							arguments(Named.of("sameInstance", key1), key1, true),
+							arguments(Named.of("sameSchemaSameTopicSameNullEncryptionKeysSameNullCustomizers",
 									new ProducerCacheKey<>(Schema.STRING, "topic1", null, null)),
-							new ProducerCacheKey<>(Schema.STRING, "topic1", null, null), true),
-					arguments(
-							Named.of("sameSchemaSameTopicSameNonNullRouterSameNullInterceptors",
-									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, null)),
-							new ProducerCacheKey<>(Schema.STRING, "topic1", router1, null), true),
-					arguments(
-							Named.of("differentSchemaInstanceSameSchemaType",
-									new ProducerCacheKey<>(new StringSchema(), "topic1", router1, null)),
-							new ProducerCacheKey<>(new StringSchema(), "topic1", router1, null), true),
-					arguments(
-							Named.of("differentSchemaType",
-									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, interceptors1)),
-							new ProducerCacheKey<>(Schema.INT64, "topic1", router1, interceptors1), false),
-					arguments(
-							Named.of("differentTopic",
-									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, interceptors1)),
-							new ProducerCacheKey<>(Schema.STRING, "topic2", router1, interceptors1), false),
-					arguments(
-							Named.of("differentNonNullRouter",
-									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, null)),
-							new ProducerCacheKey<>(Schema.STRING, "topic1", mock(MessageRouter.class), null), false),
-					arguments(
-							Named.of("differentNullRouter",
-									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, null)),
-							new ProducerCacheKey<>(Schema.STRING, "topic1", null, null), false),
-					arguments(
-							Named.of("differentNonNullInterceptors",
-									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, interceptors1)),
-							new ProducerCacheKey<>(Schema.STRING, "topic1", router1,
-									Collections.singletonList(mock(ProducerInterceptor.class))),
-							false),
-					arguments(
-							Named.of("differentNullInterceptor",
-									new ProducerCacheKey<>(Schema.STRING, "topic1", router1, interceptors1)),
-							new ProducerCacheKey<>(Schema.STRING, "topic1", null, null), false));
+									new ProducerCacheKey<>(Schema.STRING, "topic1", null, null), true),
+							arguments(
+									Named.of("sameSchemaSameTopicSameNonNullEncryptionKeysSameNullCustomizers",
+											new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1, null)),
+									new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1, null), true),
+							arguments(
+									Named.of("differentSchemaInstanceSameSchemaType",
+											new ProducerCacheKey<>(new StringSchema(), "topic1", encryptionKeys1,
+													null)),
+									new ProducerCacheKey<>(new StringSchema(), "topic1", encryptionKeys1, null), true),
+							arguments(
+									Named.of("differentSchemaType",
+											new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1, null)),
+									new ProducerCacheKey<>(Schema.INT64, "topic1", encryptionKeys1, null), false),
+							arguments(
+									Named.of("differentTopic",
+											new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1,
+													customizers1)),
+									new ProducerCacheKey<>(Schema.STRING, "topic2", encryptionKeys1, customizers1),
+									false),
+							arguments(
+									Named.of("differentNonNullEncryptionKeys",
+											new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1, null)),
+									new ProducerCacheKey<>(Schema.STRING, "topic1", Set.of("key2"), null), false),
+							arguments(
+									Named.of("differentNullEncryptionKeys",
+											new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1, null)),
+									new ProducerCacheKey<>(Schema.STRING, "topic1", null, null), false),
+							arguments(
+									Named.of("differentNonNullCustomizers",
+											new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1,
+													customizers1)),
+									new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1,
+											Collections.singletonList(mock(ProducerBuilderCustomizer.class))),
+									false),
+							arguments(
+									Named.of("differentNullInterceptor",
+											new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1,
+													customizers1)),
+									new ProducerCacheKey<>(Schema.STRING, "topic1", null, null), false));
 		}
 
 	}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
@@ -19,7 +19,6 @@ package org.springframework.pulsar.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
@@ -106,14 +106,13 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	void createProducerWithMatrixOfCacheKeys() throws PulsarClientException {
 		String topic1 = "topic1";
 		String topic2 = "topic2";
 		Schema<String> schema1 = new StringSchema();
 		Schema<String> schema2 = new StringSchema();
-		List<ProducerBuilderCustomizer<String>> customizers1 = List.of(mock(ProducerBuilderCustomizer.class));
-		List<ProducerBuilderCustomizer<String>> customizers2 = List.of(mock(ProducerBuilderCustomizer.class));
+		List<ProducerBuilderCustomizer<String>> customizers1 = List.of(p -> p.property("key", "value"));
+		List<ProducerBuilderCustomizer<String>> customizers2 = List.of(p -> p.property("key", "value"));
 		Set<String> encryptionKeys1 = Set.of("key1");
 		Set<String> encryptionKeys2 = Set.of("key2");
 
@@ -278,11 +277,9 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 			}
 		}
 
-		@SuppressWarnings("unchecked")
 		static Stream<Arguments> equalsAndHashCodeTestProvider() {
 			Set<String> encryptionKeys1 = Set.of("key1");
-			List<ProducerBuilderCustomizer<String>> customizers1 = Collections
-					.singletonList(mock(ProducerBuilderCustomizer.class));
+			List<ProducerBuilderCustomizer<String>> customizers1 = List.of(p -> p.property("key", "value"));
 			ProducerCacheKey<String> key1 = new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1,
 					customizers1);
 			return Stream
@@ -324,7 +321,7 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 											new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1,
 													customizers1)),
 									new ProducerCacheKey<>(Schema.STRING, "topic1", encryptionKeys1,
-											Collections.singletonList(mock(ProducerBuilderCustomizer.class))),
+											List.of(p -> p.property("key", "value"))),
 									false),
 							arguments(
 									Named.of("differentNullInterceptor",

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultPulsarProducerFactoryTests.java
@@ -38,9 +38,9 @@ class DefaultPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 	void createProducerMultipleCalls() throws PulsarClientException {
 		Map<String, Object> producerConfig = Collections.emptyMap();
 		PulsarProducerFactory<String> producerFactory = producerFactory(pulsarClient, producerConfig);
-		try (Producer<String> producer1 = producerFactory.createProducer("topic1", schema)) {
-			try (Producer<String> producer2 = producerFactory.createProducer("topic1", schema)) {
-				try (Producer<String> producer3 = producerFactory.createProducer("topic1", schema)) {
+		try (Producer<String> producer1 = producerFactory.createProducer(schema, "topic1")) {
+			try (Producer<String> producer2 = producerFactory.createProducer(schema, "topic1")) {
+				try (Producer<String> producer3 = producerFactory.createProducer(schema, "topic1")) {
 					assertThat(producer1).isNotSameAs(producer2).isNotSameAs(producer3);
 				}
 			}

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/FailoverConsumerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/FailoverConsumerTests.java
@@ -84,9 +84,12 @@ class FailoverConsumerTests implements PulsarTestContainerSupport {
 				pulsarClient, prodConfig);
 		final PulsarTemplate<String> pulsarTemplate = new PulsarTemplate<>(pulsarProducerFactory);
 
-		pulsarTemplate.newMessage("hello john doe").withCustomRouter(new FooRouter()).sendAsync();
-		pulsarTemplate.newMessage("hello alice doe").withCustomRouter(new BarRouter()).sendAsync();
-		pulsarTemplate.newMessage("hello buzz doe").withCustomRouter(new BuzzRouter()).sendAsync();
+		pulsarTemplate.newMessage("hello john doe")
+				.withProducerCustomizer(builder -> builder.messageRouter(new FooRouter())).sendAsync();
+		pulsarTemplate.newMessage("hello alice doe")
+				.withProducerCustomizer(builder -> builder.messageRouter(new BarRouter())).sendAsync();
+		pulsarTemplate.newMessage("hello buzz doe")
+				.withProducerCustomizer(builder -> builder.messageRouter(new BuzzRouter())).sendAsync();
 
 		final boolean await = latch.await(10, TimeUnit.SECONDS);
 		assertThat(await).isTrue();

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
@@ -51,7 +51,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.pulsar.core.PulsarOperations.SendMessageBuilder;
 
 /**
- * Tests for {@code PulsarTemplate}.
+ * Tests for {@link PulsarTemplate}.
  *
  * @author Soby Chacko
  * @author Chris Bono

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
@@ -84,7 +84,7 @@ class PulsarTemplateTests implements PulsarTestContainerSupport {
 	}
 
 	@Test
-	void sendMessageWithSpecificSchemaTest() throws Exception {
+	void sendMessageWithSpecificSchema() throws Exception {
 		String topic = "smt-specific-schema-topic";
 		try (PulsarClient client = PulsarClient.builder().serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl())
 				.build()) {
@@ -104,7 +104,7 @@ class PulsarTemplateTests implements PulsarTestContainerSupport {
 
 	@Test
 	@SuppressWarnings("unchecked")
-	void sendMessageWithEncryptionKeysTest() throws Exception {
+	void sendMessageWithEncryptionKeys() throws Exception {
 		String topic = "smt-encryption-keys-topic";
 		try (PulsarClient client = PulsarClient.builder().serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl())
 				.build()) {


### PR DESCRIPTION
* Remove `MessageRouter` and `List<Interceptor>` from the `createConsumer` params as they can be configured through `ProducerBuilderCustomizer`