### PR TITLE
PulsarAdministration now respects auth properties

### DIFF
--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarProperties.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarProperties.java
@@ -51,6 +51,7 @@ import org.springframework.util.unit.DataSize;
  * @author Soby Chacko
  * @author Alexander Preuß
  * @author Christophe Bornet
+ * @author Chris Bono
  */
 @ConfigurationProperties(prefix = "spring.pulsar")
 public class PulsarProperties {
@@ -1609,9 +1610,9 @@ public class PulsarProperties {
 		}
 
 		public Map<String, Object> buildProperties() {
-			if (!StringUtils.hasText(this.getAuthParams()) && !CollectionUtils.isEmpty(this.getAuthentication())) {
+			if (StringUtils.hasText(this.getAuthParams()) && !CollectionUtils.isEmpty(this.getAuthentication())) {
 				throw new IllegalArgumentException(
-						"Cannot set both spring.pulsar.admin.authParams and spring.pulsar.admin.authentication.*");
+						"Cannot set both spring.pulsar.administration.authParams and spring.pulsar.administration.authentication.*");
 			}
 			PulsarProperties.Properties properties = new Properties();
 

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarPropertiesTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarPropertiesTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySource;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+
+/**
+ * Unit tests for {@link PulsarProperties}.
+ *
+ * @author Chris Bono
+ */
+public class PulsarPropertiesTests {
+
+	private final PulsarProperties properties = new PulsarProperties();
+
+	private void bind(String name, String value) {
+		bind(Collections.singletonMap(name, value));
+	}
+
+	private void bind(Map<String, String> map) {
+		ConfigurationPropertySource source = new MapConfigurationPropertySource(map);
+		new Binder(source).bind("spring.pulsar", Bindable.ofInstance(this.properties));
+	}
+
+	@Nested
+	class AdminPropertiesTests {
+
+		private String authPluginClassName = "org.apache.pulsar.client.impl.auth.AuthenticationToken";
+
+		private String authParamsStr = "{\"token\":\"1234\"}";
+
+		private String authToken = "1234";
+
+		@Test
+		void authenticationUsingAuthParamsString() {
+			Map<String, String> props = new HashMap<>();
+			props.put("spring.pulsar.administration.auth-plugin-class-name",
+					"org.apache.pulsar.client.impl.auth.AuthenticationToken");
+			props.put("spring.pulsar.administration.auth-params", authParamsStr);
+			bind(props);
+			assertThat(properties.getAdministration().getAuthParams()).isEqualTo(authParamsStr);
+			assertThat(properties.getAdministration().getAuthPluginClassName()).isEqualTo(authPluginClassName);
+			Map<String, Object> adminProps = properties.buildAdminProperties();
+			assertThat(adminProps).containsEntry("authPluginClassName", authPluginClassName).containsEntry("authParams",
+					authParamsStr);
+		}
+
+		@Test
+		void authenticationUsingAuthenticationMap() {
+			Map<String, String> props = new HashMap<>();
+			props.put("spring.pulsar.administration.auth-plugin-class-name", authPluginClassName);
+			props.put("spring.pulsar.administration.authentication.token", authToken);
+			bind(props);
+			assertThat(properties.getAdministration().getAuthentication()).containsEntry("token", authToken);
+			assertThat(properties.getAdministration().getAuthPluginClassName()).isEqualTo(authPluginClassName);
+			Map<String, Object> adminProps = properties.buildAdminProperties();
+			assertThat(adminProps).containsEntry("authPluginClassName", authPluginClassName).containsEntry("authParams",
+					authParamsStr);
+		}
+
+		@Test
+		void authenticationNotAllowedUsingBothAuthParamsStringAndAuthenticationMap() {
+			Map<String, String> props = new HashMap<>();
+			props.put("spring.pulsar.administration.auth-plugin-class-name", authPluginClassName);
+			props.put("spring.pulsar.administration.auth-params", authParamsStr);
+			props.put("spring.pulsar.administration.authentication.token", authToken);
+			bind(props);
+			assertThatIllegalArgumentException().isThrownBy(() -> properties.buildAdminProperties())
+					.withMessageContaining(
+							"Cannot set both spring.pulsar.administration.authParams and spring.pulsar.administration.authentication.*");
+		}
+
+	}
+
+}

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -82,6 +82,7 @@
 		<module name="AvoidStaticImport">
 			<property name="excludes"
 					  value="org.assertj.core.api.Assertions.*,
+				org.assertj.core.api.InstanceOfAssertFactories.type,
 				org.awaitility.Awaitility.*,
 				org.junit.jupiter.api.Assertions.*,
 				org.junit.jupiter.params.provider.Arguments.*,


### PR DESCRIPTION
This code proposal provides a workaround for the fact that the PulsarAdminBuilder does not respect the auth properties specified in the config map during a `loadConf`. 

### Details
* Commit 1: add test to show the breakage
* Commit 2: fix the breakage
* Commit 3: fix unrelated issue in properties assertion

### Next steps
* Submit fix to Apache Pulsar

Fixes #194
