### PR TITLE
Remove maxInFlight

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/ReactivePulsarListener.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/ReactivePulsarListener.java
@@ -143,16 +143,6 @@ public @interface ReactivePulsarListener {
 	String concurrency() default "";
 
 	/**
-	 * Override the container factory's {@code maxInFlight} setting for this listener. May
-	 * be a property placeholder or SpEL expression that evaluates to a {@link Number}, in
-	 * which case {@link Number#intValue()} is used to obtain the value.
-	 * <p>
-	 * SpEL {@code #{...}} and property placeholders {@code ${...}} are supported.
-	 * @return the maximum in-flight messages in the reactive client pipeline.
-	 */
-	String maxInFlight() default "";
-
-	/**
 	 * Set to true or false, to override the default setting in the container factory. May
 	 * be a property placeholder or SpEL expression that evaluates to a {@link Boolean} or
 	 * a {@link String}, in which case the {@link Boolean#parseBoolean(String)} is used to

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
@@ -354,10 +354,6 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V>
 		if (StringUtils.hasText(concurrency)) {
 			endpoint.setConcurrency(resolveExpressionAsInteger(concurrency, "concurrency"));
 		}
-		String maxInFlight = reactivePulsarListener.maxInFlight();
-		if (StringUtils.hasText(maxInFlight)) {
-			endpoint.setMaxInFlight(resolveExpressionAsInteger(maxInFlight, "maxInFlight"));
-		}
 		String useKeyOrderedProcessing = reactivePulsarListener.useKeyOrderedProcessing();
 		if (StringUtils.hasText(useKeyOrderedProcessing)) {
 			endpoint.setUseKeyOrderedProcessing(

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/reactive/AbstractReactivePulsarListenerEndpoint.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/reactive/AbstractReactivePulsarListenerEndpoint.java
@@ -76,8 +76,6 @@ public abstract class AbstractReactivePulsarListenerEndpoint<T>
 
 	private Integer concurrency;
 
-	private Integer maxInFlight;
-
 	private Boolean useKeyOrderedProcessing;
 
 	@Override
@@ -229,15 +227,6 @@ public abstract class AbstractReactivePulsarListenerEndpoint<T>
 	 */
 	public void setConcurrency(Integer concurrency) {
 		this.concurrency = concurrency;
-	}
-
-	@Override
-	public Integer getMaxInFlight() {
-		return this.maxInFlight;
-	}
-
-	public void setMaxInFlight(Integer maxInFlight) {
-		this.maxInFlight = maxInFlight;
 	}
 
 	@Override

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/reactive/DefaultReactivePulsarListenerContainerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/reactive/DefaultReactivePulsarListenerContainerFactory.java
@@ -123,13 +123,6 @@ public class DefaultReactivePulsarListenerContainerFactory<T> implements Reactiv
 			properties.setConcurrency(this.containerProperties.getConcurrency());
 		}
 
-		if (endpoint.getMaxInFlight() != null) {
-			properties.setMaxInFlight(endpoint.getMaxInFlight());
-		}
-		else {
-			properties.setMaxInFlight(this.containerProperties.getMaxInFlight());
-		}
-
 		if (endpoint.getUseKeyOrderedProcessing() != null) {
 			properties.setUseKeyOrderedProcessing(endpoint.getUseKeyOrderedProcessing());
 		}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/reactive/ReactivePulsarListenerEndpoint.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/reactive/ReactivePulsarListenerEndpoint.java
@@ -33,9 +33,6 @@ public interface ReactivePulsarListenerEndpoint<T> extends ListenerEndpoint<Reac
 	boolean isFluxListener();
 
 	@Nullable
-	Integer getMaxInFlight();
-
-	@Nullable
 	Boolean getUseKeyOrderedProcessing();
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/reactive/ReactivePulsarListenerEndpointAdapter.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/reactive/ReactivePulsarListenerEndpointAdapter.java
@@ -86,11 +86,6 @@ public class ReactivePulsarListenerEndpointAdapter<T> implements ReactivePulsarL
 	}
 
 	@Override
-	public Integer getMaxInFlight() {
-		return null;
-	}
-
-	@Override
 	public Boolean getUseKeyOrderedProcessing() {
 		return null;
 	}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/reactive/DefaultReactivePulsarMessageListenerContainer.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/reactive/DefaultReactivePulsarMessageListenerContainer.java
@@ -181,8 +181,7 @@ public non-sealed class DefaultReactivePulsarMessageListenerContainer<T>
 					.handlingTimeout(containerProperties.getHandlingTimeout());
 			if (containerProperties.getConcurrency() > 0) {
 				ConcurrentOneByOneMessagePipelineBuilder<T> concurrentPipelineBuilder = messagePipelineBuilder
-						.concurrent().concurrency(containerProperties.getConcurrency())
-						.maxInflight(containerProperties.getMaxInFlight());
+						.concurrent().concurrency(containerProperties.getConcurrency());
 				if (containerProperties.isUseKeyOrderedProcessing()) {
 					concurrentPipelineBuilder.useKeyOrderedProcessing();
 				}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/reactive/ReactivePulsarContainerProperties.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/reactive/ReactivePulsarContainerProperties.java
@@ -50,8 +50,6 @@ public class ReactivePulsarContainerProperties<T> {
 
 	private int concurrency = 0;
 
-	private int maxInFlight = 0;
-
 	private boolean useKeyOrderedProcessing = false;
 
 	public ReactivePulsarMessageHandler getMessageHandler() {
@@ -128,14 +126,6 @@ public class ReactivePulsarContainerProperties<T> {
 
 	public void setConcurrency(int concurrency) {
 		this.concurrency = concurrency;
-	}
-
-	public int getMaxInFlight() {
-		return this.maxInFlight;
-	}
-
-	public void setMaxInFlight(int maxInFlight) {
-		this.maxInFlight = maxInFlight;
 	}
 
 	public boolean isUseKeyOrderedProcessing() {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/reactive/DefaultReactivePulsarMessageListenerContainerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/reactive/DefaultReactivePulsarMessageListenerContainerTests.java
@@ -145,7 +145,6 @@ class DefaultReactivePulsarMessageListenerContainerTests implements PulsarTestCo
 		pulsarContainerProperties.setSubscriptionName(subscriptionName);
 		pulsarContainerProperties.setConcurrency(5);
 		pulsarContainerProperties.setUseKeyOrderedProcessing(true);
-		pulsarContainerProperties.setMaxInFlight(6);
 		pulsarContainerProperties.setHandlingTimeout(Duration.ofMillis(7));
 		DefaultReactivePulsarMessageListenerContainer<String> container = new DefaultReactivePulsarMessageListenerContainer<>(
 				pulsarConsumerFactory, pulsarContainerProperties);
@@ -159,7 +158,7 @@ class DefaultReactivePulsarMessageListenerContainerTests implements PulsarTestCo
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 
 		assertThat(container).extracting("pipeline", InstanceOfAssertFactories.type(ReactiveMessagePipeline.class))
-				.hasFieldOrPropertyWithValue("concurrency", 5).hasFieldOrPropertyWithValue("maxInflight", 6)
+				.hasFieldOrPropertyWithValue("concurrency", 5)
 				.hasFieldOrPropertyWithValue("handlingTimeout", Duration.ofMillis(7)).extracting("groupingFunction")
 				.isInstanceOf(DefaultMessageGroupingFunction.class);
 


### PR DESCRIPTION
There is no real use for this as the number of messages pulled is already capped by concurrency*32 (default prefetch of flatMap). 

maxInFlight may be removed from the reactive client