### PR TITLE
Remove initialSubscriptionName from sender properties

### DIFF
--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarProperties.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarProperties.java
@@ -528,11 +528,6 @@ public class PulsarProperties {
 		private CompressionType compressionType;
 
 		/**
-		 * Name of the initial subscription of the topic.
-		 */
-		private String initialSubscriptionName;
-
-		/**
 		 * Type of access to the topic the producer requires.
 		 */
 		private ProducerAccessMode producerAccessMode = ProducerAccessMode.Shared;
@@ -651,14 +646,6 @@ public class PulsarProperties {
 			this.compressionType = compressionType;
 		}
 
-		public String getInitialSubscriptionName() {
-			return this.initialSubscriptionName;
-		}
-
-		public void setInitialSubscriptionName(String initialSubscriptionName) {
-			this.initialSubscriptionName = initialSubscriptionName;
-		}
-
 		public ProducerAccessMode getProducerAccessMode() {
 			return this.producerAccessMode;
 		}
@@ -692,7 +679,6 @@ public class PulsarProperties {
 			map.from(this::isBatchingEnabled).to(properties.in("batchingEnabled"));
 			map.from(this::isChunkingEnabled).to(properties.in("chunkingEnabled"));
 			map.from(this::getCompressionType).to(properties.in("compressionType"));
-			map.from(this::getInitialSubscriptionName).to(properties.in("initialSubscriptionName"));
 			map.from(this::getProducerAccessMode).to(properties.in("accessMode"));
 
 			return properties;

--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarReactiveProperties.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarReactiveProperties.java
@@ -167,11 +167,6 @@ public class PulsarReactiveProperties {
 		private CompressionType compressionType;
 
 		/**
-		 * Name of the initial subscription of the topic.
-		 */
-		private String initialSubscriptionName;
-
-		/**
 		 * Type of access to the topic the producer requires.
 		 */
 		private ProducerAccessMode producerAccessMode = ProducerAccessMode.Shared;
@@ -282,14 +277,6 @@ public class PulsarReactiveProperties {
 			this.compressionType = compressionType;
 		}
 
-		public String getInitialSubscriptionName() {
-			return this.initialSubscriptionName;
-		}
-
-		public void setInitialSubscriptionName(String initialSubscriptionName) {
-			this.initialSubscriptionName = initialSubscriptionName;
-		}
-
 		public ProducerAccessMode getProducerAccessMode() {
 			return this.producerAccessMode;
 		}
@@ -320,7 +307,6 @@ public class PulsarReactiveProperties {
 			map.from(this::getBatchingEnabled).to(spec::setBatchingEnabled);
 			map.from(this::getChunkingEnabled).to(spec::setChunkingEnabled);
 			map.from(this::getCompressionType).to(spec::setCompressionType);
-			map.from(this::getInitialSubscriptionName).to(spec::setInitialSubscriptionName);
 			map.from(this::getProducerAccessMode).to(spec::setAccessMode);
 
 			return new ImmutableReactiveMessageSenderSpec(spec);


### PR DESCRIPTION
`initialSubscriptionName` is an internal param used by the Pulsar client for DLT. It is not used in the reactive client and should be removed from `MutableReactiveMessageSenderSpec`