### PR TITLE
Extract Flux from base messaging adapter

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveMessagingMessageListenerAdapter.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveMessagingMessageListenerAdapter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.reactive.listener.adapter;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.List;
+
+import org.apache.pulsar.client.api.Messages;
+
+import org.springframework.pulsar.listener.adapter.PulsarMessagingMessageListenerAdapter;
+import org.springframework.pulsar.reactive.listener.ReactivePulsarMessageHandler;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * An abstract base for {@link ReactivePulsarMessageHandler MessageListener} adapters.
+ *
+ * @param <V> payload type.
+ * @author Chris Bono
+ */
+public abstract class PulsarReactiveMessagingMessageListenerAdapter<V>
+		extends PulsarMessagingMessageListenerAdapter<V> {
+
+	public PulsarReactiveMessagingMessageListenerAdapter(Object bean, Method method) {
+		super(bean, method);
+	}
+
+	/**
+	 * Determines if a type is one that holds multiple messages.
+	 * @param type the type to check
+	 * @return true if the type is a {@link List}, {@link Messages} or {@link Flux}, false
+	 * otherwise
+	 */
+	protected boolean isMultipleMessageType(Type type) {
+		return super.isMultipleMessageType(type) || parameterIsType(type, Flux.class);
+	}
+
+	/**
+	 * Determine if the type is a reactive Flux.
+	 * @param type type to check
+	 * @return true if the type is a reactive Flux, false otherwise
+	 */
+	@Override
+	protected boolean isFlux(Type type) {
+		return Flux.class.equals(type);
+	}
+
+}

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveOneByOneMessagingMessageListenerAdapter.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveOneByOneMessagingMessageListenerAdapter.java
@@ -22,7 +22,6 @@ import org.apache.pulsar.client.api.Message;
 import org.reactivestreams.Publisher;
 
 import org.springframework.pulsar.listener.adapter.HandlerAdapter;
-import org.springframework.pulsar.listener.adapter.PulsarMessagingMessageListenerAdapter;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarMessageHandler;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarOneByOneMessageHandler;
 
@@ -36,8 +35,8 @@ import reactor.core.publisher.Mono;
  * @param <V> payload type.
  * @author Christophe Bornet
  */
-public class PulsarReactiveOneByOneMessagingMessageListenerAdapter<V> extends PulsarMessagingMessageListenerAdapter<V>
-		implements ReactivePulsarOneByOneMessageHandler<V> {
+public class PulsarReactiveOneByOneMessagingMessageListenerAdapter<V>
+		extends PulsarReactiveMessagingMessageListenerAdapter<V> implements ReactivePulsarOneByOneMessageHandler<V> {
 
 	public PulsarReactiveOneByOneMessagingMessageListenerAdapter(Object bean, Method method) {
 		super(bean, method);

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveStreamingMessagingMessageListenerAdapter.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/listener/adapter/PulsarReactiveStreamingMessagingMessageListenerAdapter.java
@@ -22,7 +22,6 @@ import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.reactive.client.api.MessageResult;
 
 import org.springframework.pulsar.listener.adapter.HandlerAdapter;
-import org.springframework.pulsar.listener.adapter.PulsarMessagingMessageListenerAdapter;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarMessageHandler;
 import org.springframework.pulsar.reactive.listener.ReactivePulsarStreamingHandler;
 
@@ -36,8 +35,8 @@ import reactor.core.publisher.Flux;
  * @param <V> payload type.
  * @author Christophe Bornet
  */
-public class PulsarReactiveStreamingMessagingMessageListenerAdapter<V> extends PulsarMessagingMessageListenerAdapter<V>
-		implements ReactivePulsarStreamingHandler<V> {
+public class PulsarReactiveStreamingMessagingMessageListenerAdapter<V>
+		extends PulsarReactiveMessagingMessageListenerAdapter<V> implements ReactivePulsarStreamingHandler<V> {
 
 	public PulsarReactiveStreamingMessagingMessageListenerAdapter(Object bean, Method method) {
 		super(bean, method);

--- a/spring-pulsar/build.gradle
+++ b/spring-pulsar/build.gradle
@@ -22,7 +22,6 @@ dependencies {
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-joda'
 	optional 'com.jayway.jsonpath:json-path'
-	optional 'io.projectreactor:reactor-core'
 	testImplementation 'org.junit.jupiter:junit-jupiter'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testRuntimeOnly 'ch.qos.logback:logback-classic'


### PR DESCRIPTION
This pulls the usage of `Flux` out of the base messaging adapter now that we have split the modules imperative/reactive. 

NOTE: The split is a bit contrived but will require more rework on the logic in the base adapter to make it more natural. 