### PR TITLE
Change autoCertRefreshTimeMs to autoCertRefreshSeconds

### DIFF
--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarProperties.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarProperties.java
@@ -2005,7 +2005,8 @@ public class PulsarProperties {
 			map.from(this::getConnectionTimeout).asInt(Duration::toMillis).to(properties.in("connectionTimeoutMs"));
 			map.from(this::getReadTimeout).asInt(Duration::toMillis).to(properties.in("readTimeoutMs"));
 			map.from(this::getRequestTimeout).asInt(Duration::toMillis).to(properties.in("requestTimeoutMs"));
-			map.from(this::getAutoCertRefreshTime).asInt(Duration::toMillis).to(properties.in("autoCertRefreshTimeMs"));
+			map.from(this::getAutoCertRefreshTime).asInt(Duration::toSeconds)
+					.to(properties.in("autoCertRefreshSeconds"));
 
 			properties.putIfAbsent("serviceUrl", "http://localhost:8080");
 

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarPropertiesTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarPropertiesTests.java
@@ -240,11 +240,11 @@ public class PulsarPropertiesTests {
 			// the
 			// unknown readTimeout and autoCertRefreshTime properties
 			assertThatRuntimeException().isThrownBy(() -> PulsarAdmin.builder().loadConf(adminProps)).havingCause()
-					.withMessageContaining("Unrecognized field \"autoCertRefreshTimeMs\"");
+					.withMessageContaining("Unrecognized field \"autoCertRefreshSeconds\"");
 
 			assertThat(adminProps).containsEntry("serviceUrl", "my-service-url")
 					.containsEntry("connectionTimeoutMs", 12_000).containsEntry("readTimeoutMs", 13_000)
-					.containsEntry("requestTimeoutMs", 14_000).containsEntry("autoCertRefreshTimeMs", 15_000)
+					.containsEntry("requestTimeoutMs", 14_000).containsEntry("autoCertRefreshSeconds", 15)
 					.containsEntry("tlsHostnameVerificationEnable", true)
 					.containsEntry("tlsTrustCertsFilePath", "my-trust-certs-file-path")
 					.containsEntry("tlsAllowInsecureConnection", true).containsEntry("useKeyStoreTls", true)

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarAdministration.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarAdministration.java
@@ -100,8 +100,8 @@ public class PulsarAdministration
 		if (conf.remove("requestTimeoutMs") instanceof Integer requestTimeout) {
 			builder.requestTimeout(requestTimeout, TimeUnit.MILLISECONDS);
 		}
-		if (conf.remove("autoCertRefreshTimeMs") instanceof Integer autoCertRefreshTime) {
-			builder.autoCertRefreshTime(autoCertRefreshTime, TimeUnit.MILLISECONDS);
+		if (conf.remove("autoCertRefreshSeconds") instanceof Integer autoCertRefreshTime) {
+			builder.autoCertRefreshTime(autoCertRefreshTime, TimeUnit.SECONDS);
 		}
 		builder.loadConf(conf);
 


### PR DESCRIPTION
The 2.12 Pulsar client will handle the autoCertRefreshTime in CCD but the property will be named `autoCertRefreshSeconds`