### PR TITLE
Remove custom argument resolvers

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
@@ -74,7 +74,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.messaging.converter.GenericMessageConverter;
 import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
-import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.pulsar.annotation.PulsarListenerConfigurer;
 import org.springframework.pulsar.config.PulsarListenerBeanNames;
@@ -657,14 +656,6 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V>
 			GenericMessageConverter messageConverter = new GenericMessageConverter(
 					this.defaultFormattingConversionService);
 			defaultFactory.setMessageConverter(messageConverter);
-
-			List<HandlerMethodArgumentResolver> customArgumentsResolver = new ArrayList<>(
-					ReactivePulsarListenerAnnotationBeanPostProcessor.this.registrar
-							.getCustomMethodArgumentResolvers());
-			// Has to be at the end - look at PayloadMethodArgumentResolver documentation
-			// customArgumentsResolver.add(new
-			// PulsarNullAwarePayloadArgumentResolver(messageConverter, validator));
-			defaultFactory.setCustomArgumentResolvers(customArgumentsResolver);
 
 			defaultFactory.afterPropertiesSet();
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
@@ -75,7 +75,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.messaging.converter.GenericMessageConverter;
 import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
-import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.pulsar.config.MethodPulsarListenerEndpoint;
 import org.springframework.pulsar.config.PulsarListenerBeanNames;
@@ -712,13 +711,6 @@ public class PulsarListenerAnnotationBeanPostProcessor<V>
 			GenericMessageConverter messageConverter = new GenericMessageConverter(
 					this.defaultFormattingConversionService);
 			defaultFactory.setMessageConverter(messageConverter);
-
-			List<HandlerMethodArgumentResolver> customArgumentsResolver = new ArrayList<>(
-					PulsarListenerAnnotationBeanPostProcessor.this.registrar.getCustomMethodArgumentResolvers());
-			// Has to be at the end - look at PayloadMethodArgumentResolver documentation
-			// customArgumentsResolver.add(new
-			// PulsarNullAwarePayloadArgumentResolver(messageConverter, validator));
-			defaultFactory.setCustomArgumentResolvers(customArgumentsResolver);
 
 			defaultFactory.afterPropertiesSet();
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/PulsarListenerEndpointRegistrar.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/PulsarListenerEndpointRegistrar.java
@@ -17,8 +17,6 @@
 package org.springframework.pulsar.config;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -71,14 +69,6 @@ public class PulsarListenerEndpointRegistrar implements BeanFactoryAware, Initia
 	@Nullable
 	public ListenerEndpointRegistry getEndpointRegistry() {
 		return this.endpointRegistry;
-	}
-
-	public List<HandlerMethodArgumentResolver> getCustomMethodArgumentResolvers() {
-		return Collections.unmodifiableList(this.customMethodArgumentResolvers);
-	}
-
-	public void setCustomMethodArgumentResolvers(HandlerMethodArgumentResolver... methodArgumentResolvers) {
-		this.customMethodArgumentResolvers = Arrays.asList(methodArgumentResolvers);
 	}
 
 	public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory PulsarHandlerMethodFactory) {


### PR DESCRIPTION
- Remove custom argument resolvers from PulsarListenerEndpointRegistrar, as this is an un-used feature at the moment.

- The default HandlerMethodArgumentResolver is capable of adapting the all the method arguments in all the PulsarListener use cases we encountered so far. We will add it back if custom argument resolution is necessary.