### PR TITLE
Remove custom MessageHandlerMethodFactory

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/config/annotation/ReactivePulsarListenerAnnotationBeanPostProcessor.java
@@ -86,7 +86,6 @@ import org.springframework.pulsar.reactive.core.ReactiveMessageConsumerBuilderCu
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.validation.Validator;
 
 /**
  * Bean post-processor that registers methods annotated with
@@ -222,16 +221,7 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V>
 		if (this.defaultContainerFactoryBeanName != null) {
 			this.registrar.setContainerFactoryBeanName(this.defaultContainerFactoryBeanName);
 		}
-
-		// Set the custom handler method factory once resolved by the configurer -
-		// otherwise register default formatters
-		MessageHandlerMethodFactory handlerMethodFactory = this.registrar.getMessageHandlerMethodFactory();
-		if (handlerMethodFactory != null) {
-			this.messageHandlerMethodFactory.setHandlerMethodFactory(handlerMethodFactory);
-		}
-		else {
-			addFormatters(this.messageHandlerMethodFactory.defaultFormattingConversionService);
-		}
+		addFormatters(this.messageHandlerMethodFactory.defaultFormattingConversionService);
 
 		// Actually register all listeners
 		this.registrar.afterPropertiesSet();
@@ -644,10 +634,6 @@ public class ReactivePulsarListenerAnnotationBeanPostProcessor<V>
 
 		private MessageHandlerMethodFactory createDefaultMessageHandlerMethodFactory() {
 			DefaultMessageHandlerMethodFactory defaultFactory = new DefaultMessageHandlerMethodFactory();
-			Validator validator = ReactivePulsarListenerAnnotationBeanPostProcessor.this.registrar.getValidator();
-			if (validator != null) {
-				defaultFactory.setValidator(validator);
-			}
 			defaultFactory.setBeanFactory(ReactivePulsarListenerAnnotationBeanPostProcessor.this.beanFactory);
 			this.defaultFormattingConversionService.addConverter(
 					new BytesToStringConverter(ReactivePulsarListenerAnnotationBeanPostProcessor.this.charset));

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/annotation/PulsarListenerAnnotationBeanPostProcessor.java
@@ -86,7 +86,6 @@ import org.springframework.pulsar.listener.PulsarConsumerErrorHandler;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.validation.Validator;
 
 /**
  * Bean post-processor that registers methods annotated with {@link PulsarListener} to be
@@ -223,16 +222,7 @@ public class PulsarListenerAnnotationBeanPostProcessor<V>
 			this.registrar.setContainerFactoryBeanName(this.defaultContainerFactoryBeanName);
 		}
 
-		// Set the custom handler method factory once resolved by the configurer -
-		// otherwise register default formatters
-		MessageHandlerMethodFactory handlerMethodFactory = this.registrar.getMessageHandlerMethodFactory();
-		if (handlerMethodFactory != null) {
-			this.messageHandlerMethodFactory.setHandlerMethodFactory(handlerMethodFactory);
-		}
-		else {
-			addFormatters(this.messageHandlerMethodFactory.defaultFormattingConversionService);
-		}
-
+		addFormatters(this.messageHandlerMethodFactory.defaultFormattingConversionService);
 		// Actually register all listeners
 		this.registrar.afterPropertiesSet();
 	}
@@ -699,10 +689,6 @@ public class PulsarListenerAnnotationBeanPostProcessor<V>
 
 		private MessageHandlerMethodFactory createDefaultMessageHandlerMethodFactory() {
 			DefaultMessageHandlerMethodFactory defaultFactory = new DefaultMessageHandlerMethodFactory();
-			Validator validator = PulsarListenerAnnotationBeanPostProcessor.this.registrar.getValidator();
-			if (validator != null) {
-				defaultFactory.setValidator(validator);
-			}
 			defaultFactory.setBeanFactory(PulsarListenerAnnotationBeanPostProcessor.this.beanFactory);
 			this.defaultFormattingConversionService
 					.addConverter(new BytesToStringConverter(PulsarListenerAnnotationBeanPostProcessor.this.charset));

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/PulsarListenerEndpointRegistrar.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/PulsarListenerEndpointRegistrar.java
@@ -23,9 +23,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.lang.Nullable;
-import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
 import org.springframework.util.Assert;
-import org.springframework.validation.Validator;
 
 /**
  * Helper bean for registering {@link ListenerEndpoint} with a
@@ -42,10 +40,6 @@ public class PulsarListenerEndpointRegistrar implements BeanFactoryAware, Initia
 	private final List<PulsarListenerEndpointDescriptor> endpointDescriptors = new ArrayList<>();
 
 	private ListenerEndpointRegistry endpointRegistry;
-
-	private Validator validator;
-
-	private MessageHandlerMethodFactory messageHandlerMethodFactory;
 
 	private ListenerContainerFactory<?, ?> containerFactory;
 
@@ -68,16 +62,6 @@ public class PulsarListenerEndpointRegistrar implements BeanFactoryAware, Initia
 		return this.endpointRegistry;
 	}
 
-	public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory PulsarHandlerMethodFactory) {
-		Assert.isNull(this.validator, "A validator cannot be provided with a custom message handler factory");
-		this.messageHandlerMethodFactory = PulsarHandlerMethodFactory;
-	}
-
-	@Nullable
-	public MessageHandlerMethodFactory getMessageHandlerMethodFactory() {
-		return this.messageHandlerMethodFactory;
-	}
-
 	public void setContainerFactory(ListenerContainerFactory<?, ?> containerFactory) {
 		this.containerFactory = containerFactory;
 	}
@@ -89,17 +73,6 @@ public class PulsarListenerEndpointRegistrar implements BeanFactoryAware, Initia
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
-	}
-
-	@Nullable
-	public Validator getValidator() {
-		return this.validator;
-	}
-
-	public void setValidator(Validator validator) {
-		Assert.isNull(this.messageHandlerMethodFactory,
-				"A validator cannot be provided with a custom message handler factory");
-		this.validator = validator;
 	}
 
 	@Override


### PR DESCRIPTION
- Remove custom MessageHandlerMethodFactory from PulsarListenerEndpointRegistrar
- We will reintroduce it, if there is a valid use case that requires it