### PR TITLE
Remove proxy from CachingPulsarProducerFactory

### DIFF
--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/SpringPulsarBootAppSanityTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/SpringPulsarBootAppSanityTests.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -44,7 +43,6 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Chris Bono
  */
 @SpringBootTest(classes = SpringPulsarBootTestApp.class, webEnvironment = WebEnvironment.RANDOM_PORT)
-@Disabled("temporarily")
 class SpringPulsarBootAppSanityTests implements PulsarTestContainerSupport {
 
 	@DynamicPropertySource

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/CachingPulsarProducerFactoryTests.java
@@ -223,8 +223,8 @@ class CachingPulsarProducerFactoryTests extends PulsarProducerFactoryTests {
 
 	@SuppressWarnings("unchecked")
 	private Producer<String> actualProducerFrom(Producer<String> wrappedProducer) {
-        assertThat(wrappedProducer).isInstanceOf(ProducerWithCloseCallback.class);
-        return ((ProducerWithCloseCallback)wrappedProducer).getActualProducer();
+		assertThat(wrappedProducer).isInstanceOf(ProducerWithCloseCallback.class);
+		return ((ProducerWithCloseCallback) wrappedProducer).getActualProducer();
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
- Replaces the AOP proxy with a simple delegate POJO for the created producer.

- The AOP proxy was causing issues for AOT/Native