### PR TITLE
Listener endpoints use schema resolver

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run Gradle build
         run: |
-          ./gradlew clean build -DdownloadRabbitConnector=true --continue --scan
+          ./gradlew clean build -DdownloadRabbitConnector=false --continue --scan
 
       - name: Capture Test Results
         if: failure()

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/SchemaResolver.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/SchemaResolver.java
@@ -17,7 +17,9 @@
 package org.springframework.pulsar.core;
 
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.common.schema.SchemaType;
 
+import org.springframework.core.ResolvableType;
 import org.springframework.lang.Nullable;
 
 /**
@@ -60,5 +62,15 @@ public interface SchemaResolver {
 	 */
 	@Nullable
 	<T> Schema<T> getSchema(Class<?> messageType, boolean returnDefault);
+
+	/**
+	 * Get the schema to use given a schema type and a message type.
+	 * @param <T> the schema type
+	 * @param schemaType the schema type
+	 * @param messageType the message type
+	 * @return the schema to use
+	 */
+	@Nullable
+	<T> Schema<T> getSchema(SchemaType schemaType, @Nullable ResolvableType messageType);
 
 }

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultSchemaResolverTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultSchemaResolverTests.java
@@ -17,9 +17,13 @@
 package org.springframework.pulsar.core;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
 
 import java.nio.ByteBuffer;
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -31,10 +35,24 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.schema.KeyValueSchema;
+import org.apache.pulsar.client.impl.schema.AvroSchema;
+import org.apache.pulsar.client.impl.schema.JSONSchema;
+import org.apache.pulsar.client.impl.schema.ProtobufSchema;
+import org.apache.pulsar.common.schema.KeyValue;
+import org.apache.pulsar.common.schema.KeyValueEncodingType;
+import org.apache.pulsar.common.schema.SchemaType;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.pulsar.listener.Proto;
+import org.springframework.pulsar.listener.Proto.Person;
 
 /**
  * Unit tests for {@link DefaultSchemaResolver}.
@@ -43,112 +61,254 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 class DefaultSchemaResolverTests {
 
-	@ParameterizedTest
-	@MethodSource("schemaByMessageInstanceProvider")
-	<T> void getSchemaByMessageInstance(T message, Schema<T> expectedSchema) {
-		DefaultSchemaResolver resolver = new DefaultSchemaResolver();
-		assertThat(resolver.getSchema(message)).isEqualTo(expectedSchema);
+	private DefaultSchemaResolver resolver = new DefaultSchemaResolver();
+
+	@Nested
+	class SchemaByMessageInstance {
+
+		@ParameterizedTest
+		@MethodSource("primitiveTypeMessagesProvider")
+		<T> void primitiveTypeMessages(T message, Schema<T> expectedSchema) {
+			assertThat(resolver.getSchema(message)).isEqualTo(expectedSchema);
+		}
+
+		static Stream<Arguments> primitiveTypeMessagesProvider() {
+			// @formatter:off
+			return Stream.of(
+					arguments("foo".getBytes(), Schema.BYTES),
+					arguments(ByteBuffer.wrap("foo".getBytes()), Schema.BYTEBUFFER),
+					arguments(ByteBuffer.allocateDirect(10), Schema.BYTEBUFFER),
+					arguments("foo", Schema.STRING),
+					arguments(Boolean.TRUE, Schema.BOOL),
+					arguments(Byte.valueOf("0"), Schema.INT8),
+					arguments((byte) 0, Schema.INT8),
+					arguments(Short.valueOf("0"), Schema.INT16),
+					arguments((short) 0, Schema.INT16),
+					arguments(Integer.valueOf("0"), Schema.INT32),
+					arguments(0, Schema.INT32),
+					arguments(Long.valueOf("0"), Schema.INT64),
+					arguments(0L, Schema.INT64),
+					arguments(Float.valueOf("2.4"), Schema.FLOAT),
+					arguments(2.5f, Schema.FLOAT),
+					arguments(Double.valueOf("2.2"), Schema.DOUBLE),
+					arguments(2.3d, Schema.DOUBLE),
+					arguments(new Date(), Schema.DATE),
+					arguments(new Time(System.currentTimeMillis()), Schema.TIME),
+					arguments(new Timestamp(System.currentTimeMillis()), Schema.TIMESTAMP),
+					arguments(Instant.now(), Schema.INSTANT),
+					arguments(LocalDate.now(), Schema.LOCAL_DATE),
+					arguments(LocalDateTime.now(), Schema.LOCAL_DATE_TIME),
+					arguments(LocalTime.NOON, Schema.LOCAL_TIME)
+			);
+			// @formatter:on
+		}
+
+		@Test
+		void customTypeMessages() {
+			Schema<?> fooSchema = Schema.AVRO(Foo.class);
+			Map<Class<?>, Schema<?>> customTypes = new HashMap<>();
+			customTypes.put(Foo.class, fooSchema);
+			customTypes.put(Bar.class, Schema.STRING);
+			DefaultSchemaResolver resolver = new DefaultSchemaResolver(customTypes);
+			assertThat(resolver.getSchema(new Foo("foo1"))).isSameAs(fooSchema);
+			assertThat(resolver.getSchema(new Bar<>("bar1"))).isEqualTo(Schema.STRING);
+			assertThat(resolver.getSchema(new Zaa("zaa1"))).isEqualTo(Schema.BYTES); // default
+		}
+
 	}
 
-	static Stream<Arguments> schemaByMessageInstanceProvider() {
-		// @formatter:off
-		return Stream.of(
-				arguments("foo", Schema.STRING),
-				arguments("foo".getBytes(), Schema.BYTES),
-				arguments(Byte.valueOf("0"), Schema.INT8),
-				arguments((byte) 0, Schema.INT8),
-				arguments(Short.valueOf("0"), Schema.INT16),
-				arguments((short) 0, Schema.INT16),
-				arguments(Integer.valueOf("0"), Schema.INT32),
-				arguments(0, Schema.INT32),
-				arguments(Long.valueOf("0"), Schema.INT64),
-				arguments(0L, Schema.INT64),
-				arguments(Boolean.TRUE, Schema.BOOL),
-				arguments(ByteBuffer.wrap("foo".getBytes()), Schema.BYTEBUFFER),
-				arguments(ByteBuffer.allocateDirect(10), Schema.BYTEBUFFER),
-				arguments(new Date(), Schema.DATE),
-				arguments(Double.valueOf("2.2"), Schema.DOUBLE),
-				arguments(2.3d, Schema.DOUBLE),
-				arguments(Float.valueOf("2.4"), Schema.FLOAT),
-				arguments(2.5f, Schema.FLOAT),
-				arguments(Instant.now(), Schema.INSTANT),
-				arguments(LocalDate.now(), Schema.LOCAL_DATE),
-				arguments(LocalDateTime.now(), Schema.LOCAL_DATE_TIME),
-				arguments(LocalTime.NOON, Schema.LOCAL_TIME)
-		);
-		// @formatter:on
+	@Nested
+	class SchemaByMessageType {
+
+		@ParameterizedTest
+		@MethodSource("primitiveMessageTypesProvider")
+		<T> void primitiveMessageTypes(Class<?> messageType, Schema<T> expectedSchema) {
+			assertThat(resolver.getSchema(messageType)).isEqualTo(expectedSchema);
+		}
+
+		static Stream<Arguments> primitiveMessageTypesProvider() {
+			// @formatter:off
+			return Stream.of(
+					arguments(byte[].class, Schema.BYTES),
+					arguments(ByteBuffer.class, Schema.BYTEBUFFER),
+					arguments(ByteBuffer.wrap("foo".getBytes()).getClass(), Schema.BYTEBUFFER),
+					arguments(ByteBuffer.allocateDirect(10).getClass(), Schema.BYTEBUFFER),
+					arguments(String.class, Schema.STRING),
+					arguments(Boolean.class, Schema.BOOL),
+					arguments(boolean.class, Schema.BOOL),
+					arguments(Byte.class, Schema.INT8),
+					arguments(byte.class, Schema.INT8),
+					arguments(Short.class, Schema.INT16),
+					arguments(short.class, Schema.INT16),
+					arguments(Integer.class, Schema.INT32),
+					arguments(int.class, Schema.INT32),
+					arguments(Long.class, Schema.INT64),
+					arguments(long.class, Schema.INT64),
+					arguments(Date.class, Schema.DATE),
+					arguments(Time.class, Schema.TIME),
+					arguments(Timestamp.class, Schema.TIMESTAMP),
+					arguments(Float.class, Schema.FLOAT),
+					arguments(float.class, Schema.FLOAT),
+					arguments(Double.class, Schema.DOUBLE),
+					arguments(double.class, Schema.DOUBLE),
+					arguments(Instant.class, Schema.INSTANT),
+					arguments(LocalDate.class, Schema.LOCAL_DATE),
+					arguments(LocalDateTime.class, Schema.LOCAL_DATE_TIME),
+					arguments(LocalTime.class, Schema.LOCAL_TIME)
+			);
+			// @formatter:on
+		}
+
+		@Test
+		void customMessageTypes() {
+			assertThat(resolver.getSchema(Foo.class, false)).isNull();
+			assertThat(resolver.getSchema(Foo.class, true)).isEqualTo(Schema.BYTES);
+			resolver = new DefaultSchemaResolver(Collections.singletonMap(Foo.class, Schema.STRING));
+			assertThat(resolver.getSchema(Foo.class, false)).isEqualTo(Schema.STRING);
+			assertThat(resolver.getSchema(Bar.class, false)).isNull();
+			assertThat(resolver.getSchema(Bar.class, true)).isEqualTo(Schema.BYTES);
+		}
+
 	}
 
-	@Test
-	void getSchemaByMessageInstanceCustomTypes() {
-		Schema<?> fooSchema = Schema.AVRO(Foo.class);
-		Map<Class<?>, Schema<?>> customTypes = new HashMap<>();
-		customTypes.put(Foo.class, fooSchema);
-		customTypes.put(Bar.class, Schema.STRING);
-		DefaultSchemaResolver resolver = new DefaultSchemaResolver(customTypes);
-		assertThat(resolver.getSchema(new Foo("foo1"))).isSameAs(fooSchema);
-		assertThat(resolver.getSchema(new Bar<>("bar1"))).isEqualTo(Schema.STRING);
-		assertThat(resolver.getSchema(new Zaa("zaa1"))).isEqualTo(Schema.BYTES); // default
-	}
+	@Nested
+	class SchemaBySchemaTypeAndMessageType {
 
-	@ParameterizedTest
-	@MethodSource("schemaByMessageTypeProvider")
-	<T> void getSchemaByMessageType(Class<?> messageType, Schema<T> expectedSchema) {
-		DefaultSchemaResolver resolver = new DefaultSchemaResolver();
-		assertThat(resolver.getSchema(messageType)).isEqualTo(expectedSchema);
-	}
+		@ParameterizedTest
+		@MethodSource("primitiveSchemasProvider")
+		<T> void primitiveSchemas(SchemaType schemaType, Schema<T> expectedSchema) {
+			assertThat(resolver.getSchema(schemaType, null)).isEqualTo(expectedSchema);
+		}
 
-	static Stream<Arguments> schemaByMessageTypeProvider() {
-		// @formatter:off
-		return Stream.of(
-				arguments(String.class, Schema.STRING),
-				arguments(byte[].class, Schema.BYTES),
-				arguments(Byte.class, Schema.INT8),
-				arguments(byte.class, Schema.INT8),
-				arguments(Short.class, Schema.INT16),
-				arguments(short.class, Schema.INT16),
-				arguments(Integer.class, Schema.INT32),
-				arguments(int.class, Schema.INT32),
-				arguments(Long.class, Schema.INT64),
-				arguments(long.class, Schema.INT64),
-				arguments(Boolean.class, Schema.BOOL),
-				arguments(boolean.class, Schema.BOOL),
-				arguments(ByteBuffer.class, Schema.BYTEBUFFER),
-				arguments(ByteBuffer.wrap("foo".getBytes()).getClass(), Schema.BYTEBUFFER),
-				arguments(ByteBuffer.allocateDirect(10).getClass(), Schema.BYTEBUFFER),
-				arguments(Date.class, Schema.DATE),
-				arguments(Double.class, Schema.DOUBLE),
-				arguments(double.class, Schema.DOUBLE),
-				arguments(Float.class, Schema.FLOAT),
-				arguments(float.class, Schema.FLOAT),
-				arguments(Instant.class, Schema.INSTANT),
-				arguments(LocalDate.class, Schema.LOCAL_DATE),
-				arguments(LocalDateTime.class, Schema.LOCAL_DATE_TIME),
-				arguments(LocalTime.class, Schema.LOCAL_TIME)
-		);
-		// @formatter:on
-	}
+		static Stream<Arguments> primitiveSchemasProvider() {
+			// @formatter:off
+			return Stream.of(
+					arguments(SchemaType.STRING, Schema.STRING),
+					arguments(SchemaType.BOOLEAN, Schema.BOOL),
+					arguments(SchemaType.INT8, Schema.INT8),
+					arguments(SchemaType.INT16, Schema.INT16),
+					arguments(SchemaType.INT32, Schema.INT32),
+					arguments(SchemaType.INT64, Schema.INT64),
+					arguments(SchemaType.FLOAT, Schema.FLOAT),
+					arguments(SchemaType.DOUBLE, Schema.DOUBLE),
+					arguments(SchemaType.DATE, Schema.DATE),
+					arguments(SchemaType.TIME, Schema.TIME),
+					arguments(SchemaType.TIMESTAMP, Schema.TIMESTAMP),
+					arguments(SchemaType.BYTES, Schema.BYTES),
+					arguments(SchemaType.INSTANT, Schema.INSTANT),
+					arguments(SchemaType.LOCAL_DATE, Schema.LOCAL_DATE),
+					arguments(SchemaType.LOCAL_TIME, Schema.LOCAL_TIME),
+					arguments(SchemaType.LOCAL_DATE_TIME, Schema.LOCAL_DATE_TIME)
+					);
+			// @formatter:on
+		}
 
-	@Test
-	void getSchemaByMessageTypeCustomTypes() {
-		Schema<?> fooSchema = Schema.AVRO(Foo.class);
-		Map<Class<?>, Schema<?>> customTypes = new HashMap<>();
-		customTypes.put(Foo.class, fooSchema);
-		customTypes.put(Bar.class, Schema.STRING);
-		DefaultSchemaResolver resolver = new DefaultSchemaResolver(customTypes);
-		assertThat(resolver.getSchema(Foo.class)).isSameAs(fooSchema);
-		assertThat(resolver.getSchema(Bar.class)).isEqualTo(Schema.STRING);
-		assertThat(resolver.getSchema(Zaa.class)).isEqualTo(Schema.BYTES); // default
-	}
+		@Test
+		void structSchemas() {
+			assertThat(resolver.getSchema(SchemaType.JSON, ResolvableType.forType(Foo.class)))
+					.isInstanceOf(JSONSchema.class)
+					.hasFieldOrPropertyWithValue("schema.fullName", sanitizedClassName(Foo.class));
+			assertThat(resolver.getSchema(SchemaType.AVRO, ResolvableType.forType(Foo.class)))
+					.isInstanceOf(AvroSchema.class)
+					.hasFieldOrPropertyWithValue("schema.fullName", sanitizedClassName(Foo.class));
+			assertThat(resolver.getSchema(SchemaType.PROTOBUF, ResolvableType.forType(Person.class)))
+					.isInstanceOf(ProtobufSchema.class)
+					.hasFieldOrPropertyWithValue("schema.fullName", sanitizedClassName(Proto.Person.class));
+			ResolvableType kvType = ResolvableType.forClassWithGenerics(KeyValue.class, String.class, Integer.class);
+			assertThat(resolver.getSchema(SchemaType.KEY_VALUE, kvType))
+					.asInstanceOf(InstanceOfAssertFactories.type(KeyValueSchema.class)).satisfies((keyValueSchema -> {
+						assertThat(keyValueSchema.getKeySchema()).isEqualTo(Schema.STRING);
+						assertThat(keyValueSchema.getValueSchema()).isEqualTo(Schema.INT32);
+						assertThat(keyValueSchema.getKeyValueEncodingType()).isEqualTo(KeyValueEncodingType.INLINE);
+					}));
+		}
 
-	@Test
-	void getSchemaByMessageTypeWithoutDefaults() {
-		DefaultSchemaResolver resolver = new DefaultSchemaResolver();
-		assertThat(resolver.getSchema(Foo.class, false)).isNull();
+		@ParameterizedTest
+		@EnumSource(value = SchemaType.class, names = { "JSON", "AVRO", "PROTOBUF", "KEY_VALUE" })
+		void structSchemasRequireMessageType(SchemaType schemaType) {
+			assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> resolver.getSchema(schemaType, null))
+					.withMessage("messageType must be specified for " + schemaType.name());
+		}
 
-		resolver = new DefaultSchemaResolver(Collections.singletonMap(Foo.class, Schema.STRING));
-		assertThat(resolver.getSchema(Foo.class, false)).isEqualTo(Schema.STRING);
-		assertThat(resolver.getSchema(Bar.class, false)).isNull();
+		@ParameterizedTest
+		@EnumSource(value = SchemaType.class, names = { "PROTOBUF_NATIVE", "AUTO", "AUTO_CONSUME", "AUTO_PUBLISH" })
+		void unsupportedSchemaTypes(SchemaType unsupportedType) {
+			assertThatExceptionOfType(IllegalArgumentException.class)
+					.isThrownBy(() -> resolver.getSchema(unsupportedType, null))
+					.withMessage("Unsupported schema type: " + unsupportedType.name());
+		}
+
+		private String sanitizedClassName(Class<?> clazz) {
+			return clazz.getName().replace("$", ".");
+		}
+
+		@Nested
+		class SchemaTypeNone {
+
+			@Test
+			void nullMessageType() {
+				assertThat(resolver.getSchema(SchemaType.NONE, null)).isEqualTo(Schema.BYTES);
+			}
+
+			@Test
+			void primitiveMessageType() {
+				assertThat(resolver.getSchema(SchemaType.NONE, ResolvableType.forType(String.class)))
+						.isEqualTo(Schema.STRING);
+			}
+
+			@Test
+			void customMessageType() {
+				assertThat(resolver.getSchema(SchemaType.NONE, ResolvableType.forType(Foo.class))).isNull();
+				resolver = new DefaultSchemaResolver(Collections.singletonMap(Foo.class, Schema.STRING));
+				assertThat(resolver.getSchema(SchemaType.NONE, ResolvableType.forType(Foo.class)))
+						.isEqualTo(Schema.STRING);
+			}
+
+			@Test
+			void primitiveKeyValueMessageType() {
+				ResolvableType kvType = ResolvableType.forClassWithGenerics(KeyValue.class, String.class,
+						Integer.class);
+				assertThat(resolver.getSchema(SchemaType.NONE, kvType))
+						.asInstanceOf(InstanceOfAssertFactories.type(KeyValueSchema.class))
+						.satisfies((keyValueSchema -> {
+							assertThat(keyValueSchema.getKeySchema()).isEqualTo(Schema.STRING);
+							assertThat(keyValueSchema.getValueSchema()).isEqualTo(Schema.INT32);
+							assertThat(keyValueSchema.getKeyValueEncodingType()).isEqualTo(KeyValueEncodingType.INLINE);
+						}));
+			}
+
+			@Test
+			void customKeyValueMessageTypeDefaultsToBytesSchema() {
+				ResolvableType kvType = ResolvableType.forClassWithGenerics(KeyValue.class, Foo.class, Bar.class);
+				assertThat(resolver.getSchema(SchemaType.NONE, kvType))
+						.asInstanceOf(InstanceOfAssertFactories.type(KeyValueSchema.class))
+						.satisfies((keyValueSchema -> {
+							assertThat(keyValueSchema.getKeySchema()).isEqualTo(Schema.BYTES);
+							assertThat(keyValueSchema.getValueSchema()).isEqualTo(Schema.BYTES);
+							assertThat(keyValueSchema.getKeyValueEncodingType()).isEqualTo(KeyValueEncodingType.INLINE);
+						}));
+			}
+
+			@Test
+			void customKeyValueMessageTypeWithCustomTypeMappings() {
+				Schema<?> fooSchema = mock(Schema.class);
+				Schema<?> barSchema = mock(Schema.class);
+				Map<Class<?>, Schema<?>> customTypes = new HashMap<>();
+				customTypes.put(Foo.class, fooSchema);
+				customTypes.put(Bar.class, barSchema);
+				resolver = new DefaultSchemaResolver(customTypes);
+				ResolvableType kvType = ResolvableType.forClassWithGenerics(KeyValue.class, Foo.class, Bar.class);
+				assertThat(resolver.getSchema(SchemaType.NONE, kvType))
+						.asInstanceOf(InstanceOfAssertFactories.type(KeyValueSchema.class))
+						.satisfies((keyValueSchema -> {
+							assertThat(keyValueSchema.getKeySchema()).isSameAs(fooSchema);
+							assertThat(keyValueSchema.getValueSchema()).isSameAs(barSchema);
+							assertThat(keyValueSchema.getKeyValueEncodingType()).isEqualTo(KeyValueEncodingType.INLINE);
+						}));
+			}
+
+		}
+
 	}
 
 	record Foo(String value) {

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/listener/PulsarListenerTests.java
@@ -86,10 +86,6 @@ import org.springframework.util.backoff.FixedBackOff;
 @DirtiesContext
 public class PulsarListenerTests implements PulsarTestContainerSupport {
 
-	static CountDownLatch latch = new CountDownLatch(1);
-	static CountDownLatch latch1 = new CountDownLatch(3);
-	static CountDownLatch latch2 = new CountDownLatch(3);
-
 	@Autowired
 	PulsarTemplate<String> pulsarTemplate;
 
@@ -153,8 +149,12 @@ public class PulsarListenerTests implements PulsarTestContainerSupport {
 	@ContextConfiguration(classes = PulsarListenerBasicTestCases.TestPulsarListenersForBasicScenario.class)
 	class PulsarListenerBasicTestCases {
 
+		static CountDownLatch latch = new CountDownLatch(1);
+		static CountDownLatch latch1 = new CountDownLatch(3);
+		static CountDownLatch latch2 = new CountDownLatch(3);
+
 		@Test
-		void testPulsarListenerWithTopicsPattern(@Autowired PulsarListenerEndpointRegistry registry) throws Exception {
+		void pulsarListenerWithTopicsPattern(@Autowired PulsarListenerEndpointRegistry registry) throws Exception {
 			PulsarMessageListenerContainer baz = registry.getListenerContainer("baz");
 			PulsarContainerProperties containerProperties = baz.getContainerProperties();
 			assertThat(containerProperties.getTopicsPattern()).isEqualTo("persistent://public/default/pattern.*");
@@ -167,7 +167,7 @@ public class PulsarListenerTests implements PulsarTestContainerSupport {
 		}
 
 		@Test
-		void testPulsarListenerProvidedConsumerProperties(@Autowired PulsarListenerEndpointRegistry registry)
+		void pulsarListenerProvidedConsumerProperties(@Autowired PulsarListenerEndpointRegistry registry)
 				throws Exception {
 
 			PulsarContainerProperties pulsarContainerProperties = registry.getListenerContainer("foo")


### PR DESCRIPTION
Removes the schema mapping code out of the method listener endpoints and into the SchemaResolver. 

See #269
