### PR TITLE
Remove setSchema API from templates

### DIFF
--- a/spring-pulsar-docs/src/main/asciidoc/schema-info/schema-info-template.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/schema-info/schema-info-template.adoc
@@ -1,19 +1,12 @@
 == Specifying Schema Information
 If you use Java primitive types, the framework auto-detects the schema for you, and you need not specify any schema types for publishing the data.
-However, if you use any complex types (such as `JSON`, `AVRO`, `PROTOBUF`, and others), you need to set the proper schema type on the `{template-class}` before invoking any send operations, as the following example shows for JSON:
-
-====
-[source, java]
-----
-template.setSchema(Schema.JSON(Foo.class));
-----
-====
+However, if you use any complex types (such as `JSON`, `AVRO`, `PROTOBUF`, and others), you need to specify the proper schema when invoking send operations on the `{template-class}`.
 
 IMPORTANT: Complex Schema types that are currently supported are JSON, AVRO, PROTOBUF, and KEY_VALUE w/ INLINE encoding.
 
 === Custom Schema Mapping
-As an alternative to specifying the schema on the `{template-class}` for complex types, the schema resolver can be configured with mappings for the types.
-This removes the need to set the schema on the template as the framework consults the resolver using the outgoing message type.
+As an alternative to specifying the schema when invoking send operations on the `{template-class}` for complex types, the schema resolver can be configured with mappings for the types.
+This removes the need to specify the schema as the framework consults the resolver using the outgoing message type.
 
 The following example shows a schema resolver customizer that adds mappings for the `User` and `Address` complex objects using `AVRO` and `JSON` schemas, respectively:
 
@@ -29,11 +22,4 @@ public SchemaResolverCustomizer<DefaultSchemaResolver> schemaResolverCustomizer(
 }
 ----
 ====
-With this configuration in place, there is no need to set the schema on the template, for example:
-====
-[source, java]
-----
-template.send("user-topic", someUserObject);
-template.send("address-topic", someAddressObject);
-----
-====
+With this configuration in place, there is no need to set specify the schema on send operations.

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/ReactiveMessageSenderUtils.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/ReactiveMessageSenderUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import org.apache.pulsar.reactive.client.api.ReactiveMessageSenderSpec;
 
+import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
 /**
@@ -32,7 +33,7 @@ final class ReactiveMessageSenderUtils {
 	private ReactiveMessageSenderUtils() {
 	}
 
-	static <T> String resolveTopicName(String userSpecifiedTopic,
+	static <T> String resolveTopicName(@Nullable String userSpecifiedTopic,
 			ReactivePulsarSenderFactory<T> reactiveMessageSenderFactory) {
 		ReactiveMessageSenderSpec reactiveMessageSenderSpec = reactiveMessageSenderFactory
 				.getReactiveMessageSenderSpec();

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/ReactivePulsarOperations.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/ReactivePulsarOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,10 @@
 package org.springframework.pulsar.reactive.core;
 
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Schema;
 import org.reactivestreams.Publisher;
+
+import org.springframework.lang.Nullable;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -27,6 +30,7 @@ import reactor.core.publisher.Mono;
  *
  * @param <T> the message payload type
  * @author Christophe Bornet
+ * @author Chris Bono
  */
 public interface ReactivePulsarOperations<T> {
 
@@ -38,13 +42,33 @@ public interface ReactivePulsarOperations<T> {
 	Mono<MessageId> send(T message);
 
 	/**
+	 * Sends a message to the specified topic in a reactive manner. default topic
+	 * @param message the message to send
+	 * @param schema the schema to use or {@code null} to use the default schema
+	 * resolution
+	 * @return the id assigned by the broker to the published message
+	 */
+	Mono<MessageId> send(T message, @Nullable Schema<T> schema);
+
+	/**
 	 * Sends a message to the specified topic in a reactive manner.
 	 * @param topic the topic to send the message to or {@code null} to send to the
 	 * default topic
 	 * @param message the message to send
 	 * @return the id assigned by the broker to the published message
 	 */
-	Mono<MessageId> send(String topic, T message);
+	Mono<MessageId> send(@Nullable String topic, T message);
+
+	/**
+	 * Sends a message to the specified topic in a reactive manner.
+	 * @param topic the topic to send the message to or {@code null} to send to the
+	 * default topic
+	 * @param message the message to send
+	 * @param schema the schema to use or {@code null} to use the default schema
+	 * resolution
+	 * @return the id assigned by the broker to the published message
+	 */
+	Mono<MessageId> send(@Nullable String topic, T message, @Nullable Schema<T> schema);
 
 	/**
 	 * Sends multiple messages to the default topic in a reactive manner.
@@ -55,6 +79,16 @@ public interface ReactivePulsarOperations<T> {
 	Flux<MessageId> send(Publisher<T> messages);
 
 	/**
+	 * Sends multiple messages to the default topic in a reactive manner.
+	 * @param messages the messages to send
+	 * @param schema the schema to use or {@code null} to use the default schema
+	 * resolution
+	 * @return the ids assigned by the broker to the published messages in the same order
+	 * as they were sent
+	 */
+	Flux<MessageId> send(Publisher<T> messages, @Nullable Schema<T> schema);
+
+	/**
 	 * Sends multiple messages to the specified topic in a reactive manner.
 	 * @param topic the topic to send the message to or {@code null} to send to the
 	 * default topic
@@ -62,7 +96,19 @@ public interface ReactivePulsarOperations<T> {
 	 * @return the ids assigned by the broker to the published messages in the same order
 	 * as they were sent
 	 */
-	Flux<MessageId> send(String topic, Publisher<T> messages);
+	Flux<MessageId> send(@Nullable String topic, Publisher<T> messages);
+
+	/**
+	 * Sends multiple messages to the specified topic in a reactive manner.
+	 * @param topic the topic to send the message to or {@code null} to send to the
+	 * default topic
+	 * @param messages the messages to send
+	 * @param schema the schema to use or {@code null} to use the default schema
+	 * resolution
+	 * @return the ids assigned by the broker to the published messages in the same order
+	 * as they were sent
+	 */
+	Flux<MessageId> send(@Nullable String topic, Publisher<T> messages, @Nullable Schema<T> schema);
 
 	/**
 	 * Create a {@link SendMessageBuilder builder} for configuring and sending a message
@@ -71,6 +117,14 @@ public interface ReactivePulsarOperations<T> {
 	 * @return the builder to configure and send the message
 	 */
 	SendMessageBuilder<T> newMessage(T message);
+
+	/**
+	 * Create a {@link SendMessageBuilder builder} for configuring and sending multiple
+	 * messages reactively.
+	 * @param messages the messages to send
+	 * @return the builder to configure and send the message
+	 */
+	SendMessageBuilder<T> newMessages(Publisher<T> messages);
 
 	/**
 	 * Builder that can be used to configure and send a message. Provides more options
@@ -86,6 +140,13 @@ public interface ReactivePulsarOperations<T> {
 		 * @return the current builder with the destination topic specified
 		 */
 		SendMessageBuilder<T> withTopic(String topic);
+
+		/**
+		 * Specify the schema to use when sending the message.
+		 * @param schema the schema to use
+		 * @return the current builder with the schema specified
+		 */
+		SendMessageBuilder<T> withSchema(Schema<T> schema);
 
 		/**
 		 * Specifies the message customizer to use to further configure the message.
@@ -108,6 +169,13 @@ public interface ReactivePulsarOperations<T> {
 		 * @return the id assigned by the broker to the published message
 		 */
 		Mono<MessageId> send();
+
+		/**
+		 * Send the messages in a reactive manner using the configured specification.
+		 * @return the ids assigned by the broker to the published messages in the same
+		 * order as they were sent
+		 */
+		Flux<MessageId> sendMany();
 
 	}
 

--- a/spring-pulsar-sample-apps/sample-app1/src/main/java/app1/SpringPulsarBootApp.java
+++ b/spring-pulsar-sample-apps/sample-app1/src/main/java/app1/SpringPulsarBootApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,11 +93,10 @@ public class SpringPulsarBootApp {
 
 		String topic = "hello-pulsar-exclusive-3";
 		PulsarTemplate<Foo> pulsarTemplate = new PulsarTemplate<>(producerFactory);
-		pulsarTemplate.setSchema(Schema.JSON(Foo.class));
 		return args -> {
 			for (int i = 0; i < 10; i++) {
 				Foo foo = new Foo(i + "-" + "Foo-" + UUID.randomUUID(), i + "-" + "Bar-" + UUID.randomUUID());
-				pulsarTemplate.send(topic, foo);
+				pulsarTemplate.send(topic, foo, Schema.JSON(Foo.class));
 			}
 		};
 	}
@@ -139,11 +138,10 @@ public class SpringPulsarBootApp {
 
 		String topic = "hello-pulsar-exclusive-5";
 		PulsarTemplate<Foo> pulsarTemplate = new PulsarTemplate<>(producerFactory);
-		pulsarTemplate.setSchema(Schema.JSON(Foo.class));
 		return args -> {
 			for (int i = 0; i < 100; i++) {
 				Foo foo = new Foo(i + "-" + "Foo-" + UUID.randomUUID(), i + "-" + "Bar-" + UUID.randomUUID());
-				pulsarTemplate.send(topic, foo);
+				pulsarTemplate.send(topic, foo, Schema.JSON(Foo.class));
 			}
 		};
 	}

--- a/spring-pulsar-sample-apps/sample-reactive/src/main/java/org.springframework.pulsar.example/ReactiveSpringPulsarBootApp.java
+++ b/spring-pulsar-sample-apps/sample-reactive/src/main/java/org.springframework.pulsar.example/ReactiveSpringPulsarBootApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,9 +88,10 @@ public class ReactiveSpringPulsarBootApp {
 
 		@Override
 		public void onApplicationEvent(ApplicationReadyEvent event) {
-			this.reactivePulsarTemplate.setSchema(Schema.JSON(Foo.class));
+			Schema<Foo> schema = Schema.JSON(Foo.class);
 			Flux.range(0, 10).map((i) -> new Foo("Foo-" + i, "Bar-" + i))
-					.as(messages -> this.reactivePulsarTemplate.send("sample-reactive-topic2", messages)).subscribe();
+					.as(messages -> this.reactivePulsarTemplate.send("sample-reactive-topic2", messages, schema))
+					.subscribe();
 		}
 
 		@ReactivePulsarListener(subscriptionName = "sample-reactive-sub2", topics = "sample-reactive-topic2",

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarListenerTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/PulsarListenerTests.java
@@ -77,8 +77,7 @@ class PulsarListenerTests implements PulsarTestContainerSupport {
 				.run("--spring.pulsar.client.serviceUrl=" + PulsarTestContainerSupport.getPulsarBrokerUrl())) {
 			@SuppressWarnings("unchecked")
 			PulsarTemplate<Foo> pulsarTemplate = context.getBean(PulsarTemplate.class);
-			pulsarTemplate.setSchema(Schema.JSON(Foo.class));
-			pulsarTemplate.send("plt-custom-topic1", new Foo("John Doe"));
+			pulsarTemplate.send("plt-custom-topic1", new Foo("John Doe"), Schema.JSON(Foo.class));
 			assertThat(LATCH_2.await(20, TimeUnit.SECONDS)).isTrue();
 		}
 	}
@@ -118,7 +117,7 @@ class PulsarListenerTests implements PulsarTestContainerSupport {
 	static class BasicListenerConfig {
 
 		@PulsarListener(subscriptionName = "plt-sub1", topics = "plt-topic1")
-		public void listen(String foo) {
+		public void listen(String ignored) {
 			LATCH_1.countDown();
 		}
 
@@ -130,7 +129,7 @@ class PulsarListenerTests implements PulsarTestContainerSupport {
 
 		@PulsarListener(subscriptionName = "plt-custom-sub1", topics = "plt-custom-topic1",
 				schemaType = SchemaType.JSON)
-		public void listen(Foo foo) {
+		public void listen(Foo ignored) {
 			LATCH_2.countDown();
 		}
 
@@ -148,7 +147,7 @@ class PulsarListenerTests implements PulsarTestContainerSupport {
 		}
 
 		@PulsarListener(subscriptionName = "plt-custom-sub2", topics = "plt-custom-topic2")
-		public void listen(Foo foo) {
+		public void listen(Foo ignored) {
 			LATCH_3.countDown();
 		}
 

--- a/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/ReactivePulsarListenerTests.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/test/java/org/springframework/pulsar/autoconfigure/ReactivePulsarListenerTests.java
@@ -86,8 +86,7 @@ class ReactivePulsarListenerTests implements PulsarTestContainerSupport {
 				.run("--spring.pulsar.client.serviceUrl=" + PulsarTestContainerSupport.getPulsarBrokerUrl())) {
 			@SuppressWarnings("unchecked")
 			ReactivePulsarTemplate<Foo> pulsarTemplate = context.getBean(ReactivePulsarTemplate.class);
-			pulsarTemplate.setSchema(Schema.JSON(Foo.class));
-			pulsarTemplate.send("rplt-custom-topic1", new Foo("John Doe")).block();
+			pulsarTemplate.send("rplt-custom-topic1", new Foo("John Doe"), Schema.JSON(Foo.class)).block();
 			assertThat(LATCH2.await(20, TimeUnit.SECONDS)).isTrue();
 		}
 	}
@@ -129,7 +128,7 @@ class ReactivePulsarListenerTests implements PulsarTestContainerSupport {
 
 		@ReactivePulsarListener(subscriptionName = "rplt-sub1", topics = "rplt-topic1",
 				consumerCustomizer = "consumerCustomizer")
-		public Mono<Void> listen(String foo) {
+		public Mono<Void> listen(String ignored) {
 			LATCH1.countDown();
 			return Mono.empty();
 		}
@@ -143,7 +142,7 @@ class ReactivePulsarListenerTests implements PulsarTestContainerSupport {
 
 		@ReactivePulsarListener(subscriptionName = "rplt-custom-sub1", topics = "rplt-custom-topic1",
 				schemaType = SchemaType.JSON, consumerCustomizer = "consumerCustomizer")
-		public Mono<Void> listen(Foo foo) {
+		public Mono<Void> listen(Foo ignored) {
 			LATCH2.countDown();
 			return Mono.empty();
 		}
@@ -164,7 +163,7 @@ class ReactivePulsarListenerTests implements PulsarTestContainerSupport {
 
 		@ReactivePulsarListener(subscriptionName = "rplt-custom-sub2", topics = "rplt-custom-topic2",
 				consumerCustomizer = "consumerCustomizer")
-		public Mono<Void> listen(Foo foo) {
+		public Mono<Void> listen(Foo ignored) {
 			LATCH3.countDown();
 			return Mono.empty();
 		}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarOperations.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
 
 import org.springframework.lang.Nullable;
 
@@ -42,6 +43,16 @@ public interface PulsarOperations<T> {
 	MessageId send(T message) throws PulsarClientException;
 
 	/**
+	 * Sends a message to the default topic in a blocking manner.
+	 * @param message the message to send
+	 * @param schema the schema to use or {@code null} to send using the default schema
+	 * resolution
+	 * @return the id assigned by the broker to the published message
+	 * @throws PulsarClientException if an error occurs
+	 */
+	MessageId send(T message, @Nullable Schema<T> schema) throws PulsarClientException;
+
+	/**
 	 * Sends a message to the specified topic in a blocking manner.
 	 * @param topic the topic to send the message to or {@code null} to send to the
 	 * default topic
@@ -52,12 +63,34 @@ public interface PulsarOperations<T> {
 	MessageId send(@Nullable String topic, T message) throws PulsarClientException;
 
 	/**
+	 * Sends a message to the specified topic in a blocking manner.
+	 * @param topic the topic to send the message to or {@code null} to send to the
+	 * default topic
+	 * @param message the message to send
+	 * @param schema the schema to use or {@code null} to send using the default schema
+	 * resolution
+	 * @return the id assigned by the broker to the published message
+	 * @throws PulsarClientException if an error occurs
+	 */
+	MessageId send(@Nullable String topic, T message, @Nullable Schema<T> schema) throws PulsarClientException;
+
+	/**
 	 * Sends a message to the default topic in a non-blocking manner.
 	 * @param message the message to send
 	 * @return a future that holds the id assigned by the broker to the published message
 	 * @throws PulsarClientException if an error occurs
 	 */
 	CompletableFuture<MessageId> sendAsync(T message) throws PulsarClientException;
+
+	/**
+	 * Sends a message to the default topic in a non-blocking manner.
+	 * @param message the message to send
+	 * @param schema the schema to use or {@code null} to send using the default schema
+	 * resolution
+	 * @return a future that holds the id assigned by the broker to the published message
+	 * @throws PulsarClientException if an error occurs
+	 */
+	CompletableFuture<MessageId> sendAsync(T message, @Nullable Schema<T> schema) throws PulsarClientException;
 
 	/**
 	 * Sends a message to the specified topic in a non-blocking manner.
@@ -68,6 +101,19 @@ public interface PulsarOperations<T> {
 	 * @throws PulsarClientException if an error occurs
 	 */
 	CompletableFuture<MessageId> sendAsync(@Nullable String topic, T message) throws PulsarClientException;
+
+	/**
+	 * Sends a message to the specified topic in a non-blocking manner.
+	 * @param topic the topic to send the message to or {@code null} to send to the
+	 * default topic
+	 * @param message the message to send
+	 * @param schema the schema to use or {@code null} to send using the default schema
+	 * resolution
+	 * @return a future that holds the id assigned by the broker to the published message
+	 * @throws PulsarClientException if an error occurs
+	 */
+	CompletableFuture<MessageId> sendAsync(@Nullable String topic, T message, @Nullable Schema<T> schema)
+			throws PulsarClientException;
 
 	/**
 	 * Create a {@link SendMessageBuilder builder} for configuring and sending a message.
@@ -90,6 +136,13 @@ public interface PulsarOperations<T> {
 		 * @return the current builder with the destination topic specified
 		 */
 		SendMessageBuilder<T> withTopic(String topic);
+
+		/**
+		 * Specify the schema to use when sending the message.
+		 * @param schema the schema to use
+		 * @return the current builder with the schema specified
+		 */
+		SendMessageBuilder<T> withSchema(Schema<T> schema);
 
 		/**
 		 * Specify the encryption keys to use.

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/PulsarTemplateTests.java
@@ -62,6 +62,117 @@ import org.springframework.pulsar.test.support.PulsarTestContainerSupport;
 class PulsarTemplateTests implements PulsarTestContainerSupport {
 
 	@ParameterizedTest(name = "{0}")
+	@MethodSource("sendMessageTestProvider")
+	void sendMessageTest(String testName, SendTestArgs testArgs) throws Exception {
+		// Use the test args to construct the params to pass to send handler
+		String topic = testName;
+		String subscription = topic + "-sub";
+		String msgPayload = topic + "-msg";
+		TypedMessageBuilderCustomizer<String> messageCustomizer = null;
+		if (testArgs.messageCustomizer) {
+			messageCustomizer = (mb) -> mb.key("foo-key");
+		}
+		ProducerBuilderCustomizer<String> producerCustomizer = null;
+		if (testArgs.producerCustomizer) {
+			producerCustomizer = (pb) -> pb.producerName("foo-producer");
+		}
+		try (PulsarClient client = PulsarClient.builder().serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl())
+				.build()) {
+			try (Consumer<String> consumer = client.newConsumer(Schema.STRING).topic(topic)
+					.subscriptionName(subscription).subscribe()) {
+				Map<String, Object> producerConfig = testArgs.explicitTopic ? Collections.emptyMap()
+						: Collections.singletonMap("topicName", topic);
+				PulsarProducerFactory<String> producerFactory = new DefaultPulsarProducerFactory<>(client,
+						producerConfig);
+				PulsarTemplate<String> pulsarTemplate = new PulsarTemplate<>(producerFactory);
+
+				Object sendResponse;
+				if (testArgs.simpleApi) {
+					if (testArgs.explicitSchema && testArgs.explicitTopic) {
+						sendResponse = testArgs.async ? pulsarTemplate.sendAsync(topic, msgPayload, Schema.STRING)
+								: pulsarTemplate.send(topic, msgPayload, Schema.STRING);
+					}
+					else if (testArgs.explicitSchema) {
+						sendResponse = testArgs.async ? pulsarTemplate.sendAsync(msgPayload, Schema.STRING)
+								: pulsarTemplate.send(msgPayload, Schema.STRING);
+					}
+					else if (testArgs.explicitTopic) {
+						sendResponse = testArgs.async ? pulsarTemplate.sendAsync(topic, msgPayload)
+								: pulsarTemplate.send(topic, msgPayload);
+					}
+					else {
+						sendResponse = testArgs.async ? pulsarTemplate.sendAsync(msgPayload)
+								: pulsarTemplate.send(msgPayload);
+					}
+				}
+				else {
+					SendMessageBuilder<String> messageBuilder = pulsarTemplate.newMessage(msgPayload);
+					if (testArgs.explicitTopic) {
+						messageBuilder = messageBuilder.withTopic(topic);
+					}
+					if (testArgs.explicitSchema) {
+						messageBuilder = messageBuilder.withSchema(Schema.STRING);
+					}
+					if (messageCustomizer != null) {
+						messageBuilder = messageBuilder.withMessageCustomizer(messageCustomizer);
+					}
+					if (producerCustomizer != null) {
+						messageBuilder = messageBuilder.withProducerCustomizer(producerCustomizer);
+					}
+					sendResponse = testArgs.async ? messageBuilder.sendAsync() : messageBuilder.send();
+				}
+
+				if (sendResponse instanceof CompletableFuture) {
+					sendResponse = ((CompletableFuture<?>) sendResponse).get(3, TimeUnit.SECONDS);
+				}
+				assertThat(sendResponse).isNotNull();
+
+				CompletableFuture<Message<String>> receiveMsgFuture = consumer.receiveAsync();
+				Message<String> msg = receiveMsgFuture.get(3, TimeUnit.SECONDS);
+
+				assertThat(msg.getData()).asString().isEqualTo(msgPayload);
+				if (messageCustomizer != null) {
+					assertThat(msg.getKey()).isEqualTo("foo-key");
+				}
+				if (producerCustomizer != null) {
+					assertThat(msg.getProducerName()).isEqualTo("foo-producer");
+				}
+				// Make sure the producer was closed by the template (albeit indirectly as
+				// client removes closed producers)
+				await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> assertThat(client).extracting("producers")
+						.asInstanceOf(InstanceOfAssertFactories.COLLECTION).isEmpty());
+			}
+		}
+	}
+
+	private static Stream<Arguments> sendMessageTestProvider() {
+		return Stream.of(arguments("simpleSend", SendTestArgs.simple().sync()),
+				arguments("simpleSendWithTopic", SendTestArgs.simple().sync().topic()),
+				arguments("simpleSendWithSchema", SendTestArgs.simple().sync().schema()),
+				arguments("simpleSendWithTopicAndSchema", SendTestArgs.simple().sync().topic().schema()),
+				arguments("simpleAsyncSend", SendTestArgs.simple().async()),
+				arguments("simpleAsyncSendWithTopic", SendTestArgs.simple().async().topic()),
+				arguments("simpleAsyncSendWithSchema", SendTestArgs.simple().async().schema()),
+				arguments("simpleAsyncSendWithTopicAndSchema", SendTestArgs.simple().async().topic().schema()),
+				arguments("fluentSend", SendTestArgs.fluent().sync()),
+				arguments("fluentSendWithSchema", SendTestArgs.fluent().sync().schema()),
+				arguments("fluentSendWithTopic", SendTestArgs.fluent().sync().topic()),
+				arguments("fluentSendWithMessageCustomizer", SendTestArgs.fluent().sync().messageCustomizer()),
+				arguments("fluentSendWithProducerCustomizer", SendTestArgs.fluent().sync().producerCustomizer()),
+				arguments("fluentSendWithTopicAndSchema", SendTestArgs.fluent().sync().topic().schema()),
+				arguments("fluentSendWithTopicAndSchemaAndCustomizers",
+						SendTestArgs.fluent().sync().topic().schema().messageCustomizer().producerCustomizer()),
+				arguments("fluentAsyncSend", SendTestArgs.fluent().async()),
+				arguments("fluentAsyncSendWithSchema", SendTestArgs.fluent().async().schema()),
+				arguments("fluentAsyncSendWithTopic", SendTestArgs.fluent().async().topic()),
+				arguments("fluentAsyncSendWithMessageCustomizer", SendTestArgs.fluent().async().messageCustomizer()),
+				arguments("fluentAsyncSendWithProducerCustomizer", SendTestArgs.fluent().async().producerCustomizer()),
+				arguments("fluentAsyncSendWithTopicAndSchema", SendTestArgs.fluent().async().topic().schema()),
+				arguments("fluentAsyncSendWithTopicAndSchemaAndCustomizers",
+						SendTestArgs.fluent().async().topic().schema().messageCustomizer().producerCustomizer()));
+	}
+
+	@ParameterizedTest(name = "{0}")
 	@MethodSource("interceptorInvocationTestProvider")
 	void interceptorInvocationTest(String topic, List<ProducerInterceptor> interceptors) throws Exception {
 		try (PulsarClient client = PulsarClient.builder().serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl())
@@ -78,9 +189,9 @@ class PulsarTemplateTests implements PulsarTestContainerSupport {
 
 	private static Stream<Arguments> interceptorInvocationTestProvider() {
 		return Stream.of(
-				arguments(Named.of("testSingleInterceptor", "iit-topic-1"),
+				arguments(Named.of("singleInterceptor", "iit-topic-1"),
 						Collections.singletonList(mock(ProducerInterceptor.class))),
-				arguments(Named.of("testMultipleInterceptors", "iit-topic-2"),
+				arguments(Named.of("multipleInterceptors", "iit-topic-2"),
 						List.of(mock(ProducerInterceptor.class), mock(ProducerInterceptor.class))));
 	}
 
@@ -94,9 +205,8 @@ class PulsarTemplateTests implements PulsarTestContainerSupport {
 				PulsarProducerFactory<Foo> producerFactory = new DefaultPulsarProducerFactory<>(client,
 						Collections.singletonMap("topicName", topic));
 				PulsarTemplate<Foo> pulsarTemplate = new PulsarTemplate<>(producerFactory);
-				pulsarTemplate.setSchema(Schema.JSON(Foo.class));
 				Foo foo = new Foo("Foo-" + UUID.randomUUID(), "Bar-" + UUID.randomUUID());
-				pulsarTemplate.send(foo);
+				pulsarTemplate.send(foo, Schema.JSON(Foo.class));
 				assertThat(consumer.receiveAsync()).succeedsWithin(Duration.ofSeconds(3)).extracting(Message::getValue)
 						.isEqualTo(foo);
 			}
@@ -104,7 +214,7 @@ class PulsarTemplateTests implements PulsarTestContainerSupport {
 	}
 
 	@Test
-	void sendMessageWithSpecificSchemaAndCustomTypeMappings() throws Exception {
+	void sendMessageWithSpecificSchemaInferredByCustomTypeMappings() throws Exception {
 		String topic = "smt-specific-schema-custom-topic";
 		try (PulsarClient client = PulsarClient.builder().serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl())
 				.build()) {
@@ -112,7 +222,7 @@ class PulsarTemplateTests implements PulsarTestContainerSupport {
 					.subscriptionName("smt-specific-schema-custom-subscription").subscribe()) {
 				PulsarProducerFactory<Foo> producerFactory = new DefaultPulsarProducerFactory<>(client,
 						Collections.singletonMap("topicName", topic));
-				// Custom schema resolver allows not calling setSchema on template
+				// Custom schema resolver allows not specifying the schema when sending
 				DefaultSchemaResolver schemaResolver = new DefaultSchemaResolver();
 				schemaResolver.addCustomSchemaMapping(Foo.class, Schema.JSON(Foo.class));
 				PulsarTemplate<Foo> pulsarTemplate = new PulsarTemplate<>(producerFactory, Collections.emptyList(),
@@ -141,156 +251,59 @@ class PulsarTemplateTests implements PulsarTestContainerSupport {
 		}
 	}
 
-	@ParameterizedTest(name = "{0}")
-	@MethodSource("sendMessageTestProvider")
-	void sendMessageTest(String testName, SendTestArgs testArgs) throws Exception {
-		// Use the test args to construct the params to pass to send handler
-		String topic = testName;
-		String subscription = topic + "-sub";
-		String msgPayload = topic + "-msg";
-		TypedMessageBuilderCustomizer<String> messageCustomizer = null;
-		if (testArgs.useMessageCustomizer) {
-			messageCustomizer = (mb) -> mb.key("foo-key");
-		}
-		ProducerBuilderCustomizer<String> producerCustomizer = null;
-		if (testArgs.useProducerCustomizer) {
-			producerCustomizer = (pb) -> pb.producerName("foo-producer");
-		}
-
-		try (PulsarClient client = PulsarClient.builder().serviceUrl(PulsarTestContainerSupport.getPulsarBrokerUrl())
-				.build()) {
-			try (Consumer<String> consumer = client.newConsumer(Schema.STRING).topic(topic)
-					.subscriptionName(subscription).subscribe()) {
-				Map<String, Object> producerConfig = testArgs.useSpecificTopic ? Collections.emptyMap()
-						: Collections.singletonMap("topicName", topic);
-				PulsarProducerFactory<String> producerFactory = new DefaultPulsarProducerFactory<>(client,
-						producerConfig);
-				PulsarTemplate<String> pulsarTemplate = new PulsarTemplate<>(producerFactory);
-				Object sendResponse;
-				if (testArgs.useSimpleApi) {
-					if (testArgs.useAsyncSend) {
-						sendResponse = testArgs.useSpecificTopic ? pulsarTemplate.sendAsync(topic, msgPayload)
-								: pulsarTemplate.sendAsync(msgPayload);
-					}
-					else {
-						sendResponse = testArgs.useSpecificTopic ? pulsarTemplate.send(topic, msgPayload)
-								: pulsarTemplate.send(msgPayload);
-					}
-				}
-				else {
-					SendMessageBuilder<String> messageBuilder = pulsarTemplate.newMessage(msgPayload);
-					if (testArgs.useSpecificTopic) {
-						messageBuilder = messageBuilder.withTopic(topic);
-					}
-					if (messageCustomizer != null) {
-						messageBuilder = messageBuilder.withMessageCustomizer(messageCustomizer);
-					}
-					if (producerCustomizer != null) {
-						messageBuilder = messageBuilder.withProducerCustomizer(producerCustomizer);
-					}
-					sendResponse = testArgs.useAsyncSend ? messageBuilder.sendAsync() : messageBuilder.send();
-				}
-
-				if (sendResponse instanceof CompletableFuture) {
-					sendResponse = ((CompletableFuture<?>) sendResponse).get(3, TimeUnit.SECONDS);
-				}
-				assertThat(sendResponse).isNotNull();
-
-				CompletableFuture<Message<String>> receiveMsgFuture = consumer.receiveAsync();
-				Message<String> msg = receiveMsgFuture.get(3, TimeUnit.SECONDS);
-
-				assertThat(msg.getData()).asString().isEqualTo(msgPayload);
-				if (messageCustomizer != null) {
-					assertThat(msg.getKey()).isEqualTo("foo-key");
-				}
-				if (producerCustomizer != null) {
-					assertThat(msg.getProducerName()).isEqualTo("foo-producer");
-				}
-				// Make sure the producer was closed by the template (albeit indirectly as
-				// client removes closed producers)
-				await().atMost(Duration.ofSeconds(3)).untilAsserted(() -> assertThat(client).extracting("producers")
-						.asInstanceOf(InstanceOfAssertFactories.COLLECTION).isEmpty());
-			}
-		}
-	}
-
-	private static Stream<Arguments> sendMessageTestProvider() {
-		return Stream.of(arguments("sendMessageToDefaultTopic", SendTestArgs.useSpecificTopic(false)),
-				arguments("sendMessageToDefaultTopicWithSimpleApi",
-						SendTestArgs.useSpecificTopic(false).useSimpleApi()),
-				arguments("sendMessageToDefaultTopicWithMessageCustomizer",
-						SendTestArgs.useSpecificTopic(false).useMessageCustomizer()),
-				arguments("sendMessageToDefaultTopicWithProducerCustomizer",
-						SendTestArgs.useSpecificTopic(false).useProducerCustomizer()),
-				arguments("sendMessageToDefaultTopicWithAllOptions",
-						SendTestArgs.useSpecificTopic(false).useMessageCustomizer().useProducerCustomizer()),
-				arguments("sendMessageToSpecificTopic", SendTestArgs.useSpecificTopic(true)),
-				arguments("sendMessageToSpecificTopicWithSimpleApi",
-						SendTestArgs.useSpecificTopic(true).useSimpleApi()),
-				arguments("sendMessageToSpecificTopicWithMessageCustomizer",
-						SendTestArgs.useSpecificTopic(true).useMessageCustomizer()),
-				arguments("sendMessageToSpecificTopicWithProducerCustomizer",
-						SendTestArgs.useSpecificTopic(true).useProducerCustomizer()),
-				arguments("sendMessageToSpecificTopicWithAllOptions",
-						SendTestArgs.useSpecificTopic(true).useMessageCustomizer().useProducerCustomizer()),
-				arguments("sendAsyncMessageToDefaultTopic", SendTestArgs.useSpecificTopic(false).useAsyncSend()),
-				arguments("sendAsyncMessageToDefaultTopicWithSimpleApi",
-						SendTestArgs.useSpecificTopic(false).useAsyncSend().useSimpleApi()),
-				arguments("sendAsyncMessageToDefaultTopicWithMessageCustomizer",
-						SendTestArgs.useSpecificTopic(false).useMessageCustomizer().useAsyncSend()),
-				arguments("sendAsyncMessageToDefaultTopicWithProducerCustomizer",
-						SendTestArgs.useSpecificTopic(false).useProducerCustomizer().useAsyncSend()),
-				arguments("sendAsyncMessageToDefaultTopicWithAllOptions",
-						SendTestArgs.useSpecificTopic(false).useMessageCustomizer().useProducerCustomizer()
-								.useAsyncSend()),
-				arguments("sendAsyncMessageToSpecificTopic", SendTestArgs.useSpecificTopic(true).useAsyncSend()),
-				arguments("sendAsyncMessageToSpecificTopicWithSimpleApi",
-						SendTestArgs.useSpecificTopic(true).useAsyncSend().useSimpleApi()),
-				arguments("sendAsyncMessageToSpecificTopicWithMessageCustomizer",
-						SendTestArgs.useSpecificTopic(true).useMessageCustomizer().useAsyncSend()),
-				arguments("sendAsyncMessageToSpecificTopicWithProducerCustomizer",
-						SendTestArgs.useSpecificTopic(true).useProducerCustomizer().useAsyncSend()),
-				arguments("sendAsyncMessageToSpecificTopicWithAllOptions", SendTestArgs.useSpecificTopic(true)
-						.useMessageCustomizer().useProducerCustomizer().useAsyncSend()));
-	}
-
 	static final class SendTestArgs {
 
-		private final boolean useSpecificTopic;
+		private final boolean simpleApi;
 
-		private boolean useMessageCustomizer;
+		private boolean async;
 
-		private boolean useProducerCustomizer;
+		private boolean explicitTopic;
 
-		private boolean useAsyncSend;
+		private boolean explicitSchema;
 
-		private boolean useSimpleApi;
+		private boolean messageCustomizer;
 
-		private SendTestArgs(boolean useSpecificTopic) {
-			this.useSpecificTopic = useSpecificTopic;
+		private boolean producerCustomizer;
+
+		private SendTestArgs(boolean simpleApi) {
+			this.simpleApi = simpleApi;
 		}
 
-		static SendTestArgs useSpecificTopic(boolean useSpecificTopic) {
-			return new SendTestArgs(useSpecificTopic);
+		static SendTestArgs simple() {
+			return new SendTestArgs(true);
 		}
 
-		SendTestArgs useMessageCustomizer() {
-			this.useMessageCustomizer = true;
+		static SendTestArgs fluent() {
+			return new SendTestArgs(false);
+		}
+
+		SendTestArgs async() {
+			this.async = true;
 			return this;
 		}
 
-		SendTestArgs useProducerCustomizer() {
-			this.useProducerCustomizer = true;
+		SendTestArgs sync() {
+			this.async = false;
 			return this;
 		}
 
-		SendTestArgs useAsyncSend() {
-			this.useAsyncSend = true;
+		SendTestArgs topic() {
+			this.explicitTopic = true;
 			return this;
 		}
 
-		SendTestArgs useSimpleApi() {
-			this.useSimpleApi = true;
+		SendTestArgs schema() {
+			this.explicitSchema = true;
+			return this;
+		}
+
+		SendTestArgs messageCustomizer() {
+			this.messageCustomizer = true;
+			return this;
+		}
+
+		SendTestArgs producerCustomizer() {
+			this.producerCustomizer = true;
 			return this;
 		}
 


### PR DESCRIPTION
For both PulsarTemplate and ReactivePulsarTemplate:

* remove setSchema()
* add schema param in simple API
* add schema param in fluent API

Update all tests and samples accordingly

See #268
