### PR TITLE
Create partitioned topics once per ns

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarAdministration.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarAdministration.java
@@ -163,10 +163,10 @@ public class PulsarAdministration
 	private void doCreateOrModifyTopicsIfNeeded(PulsarAdmin admin, Collection<PulsarTopic> topics) {
 		Map<String, List<PulsarTopic>> topicsPerNamespace = getTopicsPerNamespace(topics);
 
-		Set<PulsarTopic> topicsToCreate = new HashSet<>();
-		Set<PulsarTopic> topicsToModify = new HashSet<>();
-
 		topicsPerNamespace.forEach((namespace, requestedTopics) -> {
+			Set<PulsarTopic> topicsToCreate = new HashSet<>();
+			Set<PulsarTopic> topicsToModify = new HashSet<>();
+
 			try {
 				List<String> existingTopicsInNamespace = admin.topics().getList(namespace);
 


### PR DESCRIPTION
Thank you for the nice module, however, I faced an issue with the Administration behaviour regarding the topic creation in several namespaces.

If we define separate topics in different namespaces, the administration shouldn't try to create each topic several times. 
This PR changes the `topicsToCreate` scope to be at the same level where the creation happens. 

Otherwise, it creates the topic in one namespace, adds a topic in another namespace to the same set and without cleaning it up tries to create 2 topics, which leads to 409 response from pulsar.

This PR adds a test to demonstrate the case.


<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
