### PR TITLE
Use switchOnFirst to determine the Schema and topic from the first message in doSendMany

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarSenderFactory.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarSenderFactory.java
@@ -49,18 +49,19 @@ public class DefaultReactivePulsarSenderFactory<T> implements ReactivePulsarSend
 
 	private final ReactiveMessageSenderSpec reactiveMessageSenderSpec;
 
+	@Nullable
 	private final ReactiveMessageSenderCache reactiveMessageSenderCache;
 
 	public DefaultReactivePulsarSenderFactory(PulsarClient pulsarClient,
-			ReactiveMessageSenderSpec reactiveMessageSenderSpec,
-			ReactiveMessageSenderCache reactiveMessageSenderCache) {
+			@Nullable ReactiveMessageSenderSpec reactiveMessageSenderSpec,
+			@Nullable ReactiveMessageSenderCache reactiveMessageSenderCache) {
 		this(AdaptedReactivePulsarClientFactory.create(pulsarClient), reactiveMessageSenderSpec,
 				reactiveMessageSenderCache);
 	}
 
 	public DefaultReactivePulsarSenderFactory(ReactivePulsarClient reactivePulsarClient,
-			ReactiveMessageSenderSpec reactiveMessageSenderSpec,
-			ReactiveMessageSenderCache reactiveMessageSenderCache) {
+			@Nullable ReactiveMessageSenderSpec reactiveMessageSenderSpec,
+			@Nullable ReactiveMessageSenderCache reactiveMessageSenderCache) {
 		this.reactivePulsarClient = reactivePulsarClient;
 		this.reactiveMessageSenderSpec = new ImmutableReactiveMessageSenderSpec(
 				reactiveMessageSenderSpec != null ? reactiveMessageSenderSpec : new MutableReactiveMessageSenderSpec());

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/ReactivePulsarOperations.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/ReactivePulsarOperations.java
@@ -127,16 +127,6 @@ public interface ReactivePulsarOperations<T> {
 	SendMessageBuilder<T> newMessages(Publisher<T> messages);
 
 	/**
-	 * Create a {@link SendMessageBuilder builder} for configuring and sending multiple
-	 * messages reactively.
-	 * @param messages the messages to send
-	 * @param messageType the type of messages being sent - helpful for topic resolution
-	 * when schema is not specified during a {@code sendMany} operation
-	 * @return the builder to configure and send the message
-	 */
-	SendMessageBuilder<T> newMessages(Publisher<T> messages, Class<T> messageType);
-
-	/**
 	 * Builder that can be used to configure and send a message. Provides more options
 	 * than the send methods provided by {@link ReactivePulsarOperations}.
 	 *

--- a/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/DefaultReactivePulsarMessageListenerContainerTests.java
+++ b/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/listener/DefaultReactivePulsarMessageListenerContainerTests.java
@@ -302,6 +302,7 @@ class DefaultReactivePulsarMessageListenerContainerTests implements PulsarTestCo
 		container.setConsumerCustomizer(b -> b.deadLetterPolicy(deadLetterPolicy));
 		container.start();
 		MutableReactiveMessageSenderSpec prodConfig = new MutableReactiveMessageSenderSpec();
+		prodConfig.setBatchingEnabled(false);
 		prodConfig.setTopicName(topic);
 		DefaultReactivePulsarSenderFactory<String> pulsarProducerFactory = new DefaultReactivePulsarSenderFactory<>(
 				reactivePulsarClient, prodConfig, null);


### PR DESCRIPTION
In `doSendMany`, when we don't have an explicit Schema or topic, instead of using `sendOne` and create a sender for each message, we can use `switchOnFirst` to build the sender from the first message.
This has the following advantages:
* Can be used for both Schema and topic inference (currently only schema was supported with the sendOne workaround)
* Only one sender is created so the order is preserved even if there is no producer cache configured.
* We can remove `SendMessageBuilder::newMessages(Publisher<T>, Class<T> messageType)` as we get the messageType from the first message.
