### PR TITLE
Trim ReactivePulsarSenderFactory API

### DIFF
--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarSenderFactory.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/DefaultReactivePulsarSenderFactory.java
@@ -18,6 +18,7 @@ package org.springframework.pulsar.reactive.core;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Schema;
@@ -69,11 +70,6 @@ public class DefaultReactivePulsarSenderFactory<T> implements ReactivePulsarSend
 	}
 
 	@Override
-	public ReactiveMessageSender<T> createSender(Schema<T> schema) {
-		return doCreateReactiveMessageSender(schema, null, null);
-	}
-
-	@Override
 	public ReactiveMessageSender<T> createSender(Schema<T> schema, @Nullable String topic) {
 		return doCreateReactiveMessageSender(schema, topic, null);
 	}
@@ -93,7 +89,7 @@ public class DefaultReactivePulsarSenderFactory<T> implements ReactivePulsarSend
 
 	private ReactiveMessageSender<T> doCreateReactiveMessageSender(Schema<T> schema, @Nullable String topic,
 			@Nullable List<ReactiveMessageSenderBuilderCustomizer<T>> customizers) {
-
+		Objects.requireNonNull(schema, "Schema must be specified");
 		String resolvedTopic = ReactiveMessageSenderUtils.resolveTopicName(topic, this);
 		this.logger.trace(() -> String.format("Creating reactive message sender for '%s' topic", resolvedTopic));
 		ReactiveMessageSenderBuilder<T> sender = this.reactivePulsarClient.messageSender(schema);

--- a/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/ReactivePulsarSenderFactory.java
+++ b/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/ReactivePulsarSenderFactory.java
@@ -34,13 +34,6 @@ import org.springframework.lang.Nullable;
 public interface ReactivePulsarSenderFactory<T> {
 
 	/**
-	 * Create a reactive message sender that will send messages to the default topic.
-	 * @param schema the schema of the messages to be sent
-	 * @return the reactive message sender
-	 */
-	ReactiveMessageSender<T> createSender(Schema<T> schema);
-
-	/**
 	 * Create a reactive message sender.
 	 * @param topic the topic to send messages to or {@code null} to use the default topic
 	 * @param schema the schema of the messages to be sent

--- a/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/core/DefaultReactiveMessageSenderFactoryTests.java
+++ b/spring-pulsar-reactive/src/test/java/org/springframework/pulsar/reactive/core/DefaultReactiveMessageSenderFactoryTests.java
@@ -18,8 +18,10 @@ package org.springframework.pulsar.reactive.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.PulsarClient;
@@ -77,24 +79,13 @@ class DefaultReactiveMessageSenderFactoryTests {
 	}
 
 	@Nested
-	class CreateSenderSchemaOnlyApi {
-
-		@Test
-		void withDefaultTopic() {
-			var sender = newSenderFactoryWithDefaultTopic("topic0").createSender(schema);
-			assertThatSenderHasTopic(sender, "topic0");
-		}
-
-		@Test
-		void withoutDefaultTopic() {
-			assertThatIllegalArgumentException().isThrownBy(() -> newSenderFactory().createSender(schema))
-					.withMessageContaining("Topic must be specified when no default topic is configured");
-		}
-
-	}
-
-	@Nested
 	class CreateSenderSchemaAndTopicApi {
+
+		@Test
+		void withoutSchema() {
+			assertThatNullPointerException().isThrownBy(() -> newSenderFactory().createSender(null, "topic0"))
+					.withMessageContaining("Schema must be specified");
+		}
 
 		@Test
 		void topicSpecifiedWithDefaultTopic() {
@@ -128,6 +119,14 @@ class DefaultReactiveMessageSenderFactoryTests {
 		@Test
 		void singleCustomizer() {
 			var sender = newSenderFactory().createSender(schema, "topic1", (b) -> b.producerName("fooProducer"));
+			assertThatSenderSpecSatisfies(sender,
+					(senderSpec) -> assertThat(senderSpec.getProducerName()).isEqualTo("fooProducer"));
+		}
+
+		@Test
+		void singleCustomizerViaListApi() {
+			var sender = newSenderFactory().createSender(schema, "topic1",
+					Collections.singletonList((b) -> b.producerName("fooProducer")));
 			assertThatSenderSpecSatisfies(sender,
 					(senderSpec) -> assertThat(senderSpec.getProducerName()).isEqualTo("fooProducer"));
 		}


### PR DESCRIPTION
### What
Removes the `createProducer/Sender(Schema)` as it is likely not that useful as most users will specify a topic and not rely on the default topic. 

### Why
The thinking is that the `Reactive/PulsarTemplate` will be the users primary sending API. The producer/sender API is therefore secondary in that sense. This allows us to limit the producer/sender API surface area and remove any questionable APIs in `1.0.0` and let users drive the shape of the API `post-1.0.0`.

Additionally:
* Consistency: A goal is to keep the imperative and reactive producer/sender consistent (as much as possible). I already did this same change to the imperative PPF.  This PR applies the same treatment to the Reactive counterpart.

cc: @cbornet if you agree (don't have an issue w/ this approach) I am planning on removing the schema-only API in the consumer/readers as well:

https://github.com/spring-projects-experimental/spring-pulsar/blob/f211a3490ba40049036f7b78ba63660f984aeabe/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/ReactivePulsarConsumerFactory.java#L37

RPRF and RPCF (https://github.com/spring-projects-experimental/spring-pulsar/blob/f211a3490ba40049036f7b78ba63660f984aeabe/spring-pulsar-reactive/src/main/java/org/springframework/pulsar/reactive/core/ReactivePulsarReaderFactory.java#L37) 

