### PR TITLE
Add single customizer API in PulsarConsumerFactory

### DIFF
--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactory.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 import org.apache.pulsar.client.api.Consumer;
@@ -63,8 +64,16 @@ public class DefaultPulsarConsumerFactory<T> implements PulsarConsumerFactory<T>
 
 	@Override
 	public Consumer<T> createConsumer(Schema<T> schema, @Nullable Collection<String> topics,
+			@Nullable String subscriptionName, ConsumerBuilderCustomizer<T> customizer) throws PulsarClientException {
+		return createConsumer(schema, topics, subscriptionName, null,
+				customizer != null ? Collections.singletonList(customizer) : null);
+	}
+
+	@Override
+	public Consumer<T> createConsumer(Schema<T> schema, @Nullable Collection<String> topics,
 			@Nullable String subscriptionName, @Nullable Map<String, String> metadataProperties,
 			@Nullable List<ConsumerBuilderCustomizer<T>> customizers) throws PulsarClientException {
+		Objects.requireNonNull(schema, "Schema must be specified");
 		ConsumerBuilder<T> consumerBuilder = this.pulsarClient.newConsumer(schema);
 		Map<String, Object> config = new HashMap<>(this.consumerConfig);
 		if (topics != null) {

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarConsumerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/PulsarConsumerFactory.java
@@ -49,6 +49,27 @@ public interface PulsarConsumerFactory<T> {
 	 * topic(s) or {@code null} to use the default configured subscription name. Beware
 	 * that specifying {@code null} when no default subscription name is configured will
 	 * result in an exception
+	 * @param customizer an optional customizer to apply to the consumer builder. Note
+	 * that the customizer is applied last and has the potential for overriding any
+	 * specified parameters or default properties.
+	 * @return the consumer
+	 * @throws PulsarClientException if any error occurs
+	 */
+	Consumer<T> createConsumer(Schema<T> schema, @Nullable Collection<String> topics, @Nullable String subscriptionName,
+			ConsumerBuilderCustomizer<T> customizer) throws PulsarClientException;
+
+	/**
+	 * Create a consumer.
+	 * @param schema the schema of the messages to be sent
+	 * @param topics the topics the consumer will subscribe to, replacing the default
+	 * topics, or {@code null} to use the default topics. Beware that using
+	 * {@link ConsumerBuilder#topic} or {@link ConsumerBuilder#topics} will add to the
+	 * default topics, not override them. Also beware that specifying {@code null} when no
+	 * default topic is configured will result in an exception.
+	 * @param subscriptionName the name to use for the subscription to the consumed
+	 * topic(s) or {@code null} to use the default configured subscription name. Beware
+	 * that specifying {@code null} when no default subscription name is configured will
+	 * result in an exception
 	 * @param metadataProperties the metadata properties to attach to the consumer,
 	 * replacing the default metadata properties, or {@code null} to use the default
 	 * metadata properties. Beware that using {@link ConsumerBuilder#property} or

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactoryTests.java
@@ -79,8 +79,7 @@ class DefaultPulsarConsumerFactoryTests implements PulsarTestContainerSupport {
 		void withoutSchema() {
 			assertThatThrownBy(
 					() -> consumerFactory.createConsumer(null, Collections.singletonList("topic0"), null, null, null))
-							.isInstanceOf(NullPointerException.class)
-							.hasMessageContaining("Schema must be specified");
+							.isInstanceOf(NullPointerException.class).hasMessageContaining("Schema must be specified");
 		}
 
 		@SuppressWarnings("resource")
@@ -182,8 +181,7 @@ class DefaultPulsarConsumerFactoryTests implements PulsarTestContainerSupport {
 		void withoutSchema() {
 			assertThatThrownBy(
 					() -> consumerFactory.createConsumer(null, Collections.singletonList("topic0"), null, null, null))
-							.isInstanceOf(NullPointerException.class)
-							.hasMessageContaining("Schema must be specified");
+							.isInstanceOf(NullPointerException.class).hasMessageContaining("Schema must be specified");
 		}
 
 		@Test

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactoryTests.java
@@ -79,7 +79,7 @@ class DefaultPulsarConsumerFactoryTests implements PulsarTestContainerSupport {
 		void withoutSchema() {
 			assertThatThrownBy(
 					() -> consumerFactory.createConsumer(null, Collections.singletonList("topic0"), null, null, null))
-							.isInstanceOf(InvalidConfigurationException.class)
+							.isInstanceOf(NullPointerException.class)
 							.hasMessageContaining("Schema must be specified");
 		}
 
@@ -182,7 +182,7 @@ class DefaultPulsarConsumerFactoryTests implements PulsarTestContainerSupport {
 		void withoutSchema() {
 			assertThatThrownBy(
 					() -> consumerFactory.createConsumer(null, Collections.singletonList("topic0"), null, null, null))
-							.isInstanceOf(InvalidConfigurationException.class)
+							.isInstanceOf(NullPointerException.class)
 							.hasMessageContaining("Schema must be specified");
 		}
 

--- a/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactoryTests.java
+++ b/spring-pulsar/src/test/java/org/springframework/pulsar/core/DefaultPulsarConsumerFactoryTests.java
@@ -75,6 +75,14 @@ class DefaultPulsarConsumerFactoryTests implements PulsarTestContainerSupport {
 			consumerFactory = new DefaultPulsarConsumerFactory<>(pulsarClient, Collections.emptyMap());
 		}
 
+		@Test
+		void withoutSchema() {
+			assertThatThrownBy(
+					() -> consumerFactory.createConsumer(null, Collections.singletonList("topic0"), null, null, null))
+							.isInstanceOf(InvalidConfigurationException.class)
+							.hasMessageContaining("Schema must be specified");
+		}
+
 		@SuppressWarnings("resource")
 		@Test
 		void withSchemaOnly() {
@@ -120,6 +128,14 @@ class DefaultPulsarConsumerFactoryTests implements PulsarTestContainerSupport {
 		}
 
 		@Test
+		void withSingleCustomizerApi() throws PulsarClientException {
+			try (var consumer = consumerFactory.createConsumer(SCHEMA, Collections.singletonList("topic0"),
+					"topic0-sub", (cb) -> cb.consumerName("foo-consumer"))) {
+				assertThat(consumer.getConsumerName()).isEqualTo("foo-consumer");
+			}
+		}
+
+		@Test
 		void customizesAreAppliedLast() throws PulsarClientException {
 			try (var consumer = consumerFactory.createConsumer(SCHEMA, Collections.singletonList("topic0"),
 					"topic0-sub", null, List.of((cb) -> cb.subscriptionName("topic0-sub2")))) {
@@ -160,6 +176,14 @@ class DefaultPulsarConsumerFactoryTests implements PulsarTestContainerSupport {
 			defaultConfig.put("properties", defaultMetadataProperties);
 			defaultConfig.put("subscriptionName", defaultSubscription);
 			consumerFactory = new DefaultPulsarConsumerFactory<>(pulsarClient, defaultConfig);
+		}
+
+		@Test
+		void withoutSchema() {
+			assertThatThrownBy(
+					() -> consumerFactory.createConsumer(null, Collections.singletonList("topic0"), null, null, null))
+							.isInstanceOf(InvalidConfigurationException.class)
+							.hasMessageContaining("Schema must be specified");
 		}
 
 		@Test


### PR DESCRIPTION
Adding back in the "all required args + single customizer" API variant as this:

1. can be useful when user wants to modify something simple and not provide enc keys and list of customizers
2. consistent w/ sender/producer single customizer APIs
3. compromise of only providing a single API that has all required params