### PR TITLE
Pulsar binder partition count defaults

### DIFF
--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarBinderConfigurationProperties.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarBinderConfigurationProperties.java
@@ -36,7 +36,7 @@ public class PulsarBinderConfigurationProperties {
 	@NestedConfigurationProperty
 	private final ProducerConfigProperties producer = new ProducerConfigProperties();
 
-	private int partitionCount = 1;
+	private int partitionCount = 0;
 
 	public ConsumerConfigProperties getConsumer() {
 		return this.consumer;

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarBinderConfigurationProperties.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarBinderConfigurationProperties.java
@@ -18,6 +18,7 @@ package org.springframework.pulsar.spring.cloud.stream.binder.properties;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.lang.Nullable;
 import org.springframework.pulsar.autoconfigure.ConsumerConfigProperties;
 import org.springframework.pulsar.autoconfigure.ProducerConfigProperties;
 
@@ -36,7 +37,8 @@ public class PulsarBinderConfigurationProperties {
 	@NestedConfigurationProperty
 	private final ProducerConfigProperties producer = new ProducerConfigProperties();
 
-	private int partitionCount = 0;
+	@Nullable
+	private Integer partitionCount;
 
 	public ConsumerConfigProperties getConsumer() {
 		return this.consumer;
@@ -46,11 +48,12 @@ public class PulsarBinderConfigurationProperties {
 		return this.producer;
 	}
 
-	public int partitionCount() {
+	@Nullable
+	public Integer getPartitionCount() {
 		return this.partitionCount;
 	}
 
-	public void setPartitionCount(int partitionCount) {
+	public void setPartitionCount(Integer partitionCount) {
 		this.partitionCount = partitionCount;
 	}
 

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarConsumerProperties.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarConsumerProperties.java
@@ -41,7 +41,7 @@ public class PulsarConsumerProperties extends ConsumerConfigProperties {
 	@Nullable
 	private Class<?> messageValueType;
 
-	private Integer partitionCount = 1;
+	private int partitionCount = 0;
 
 	@Nullable
 	public SchemaType getSchemaType() {
@@ -79,11 +79,11 @@ public class PulsarConsumerProperties extends ConsumerConfigProperties {
 		this.messageValueType = messageValueType;
 	}
 
-	public Integer getPartitionCount() {
+	public int getPartitionCount() {
 		return this.partitionCount;
 	}
 
-	public void setPartitionCount(Integer partitionCount) {
+	public void setPartitionCount(int partitionCount) {
 		this.partitionCount = partitionCount;
 	}
 

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarConsumerProperties.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarConsumerProperties.java
@@ -41,7 +41,8 @@ public class PulsarConsumerProperties extends ConsumerConfigProperties {
 	@Nullable
 	private Class<?> messageValueType;
 
-	private int partitionCount = 0;
+	@Nullable
+	private Integer partitionCount;
 
 	@Nullable
 	public SchemaType getSchemaType() {
@@ -79,11 +80,12 @@ public class PulsarConsumerProperties extends ConsumerConfigProperties {
 		this.messageValueType = messageValueType;
 	}
 
-	public int getPartitionCount() {
+	@Nullable
+	public Integer getPartitionCount() {
 		return this.partitionCount;
 	}
 
-	public void setPartitionCount(int partitionCount) {
+	public void setPartitionCount(Integer partitionCount) {
 		this.partitionCount = partitionCount;
 	}
 

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarProducerProperties.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarProducerProperties.java
@@ -41,6 +41,8 @@ public class PulsarProducerProperties extends ProducerConfigProperties {
 	@Nullable
 	private Class<?> messageValueType;
 
+	private int partitionCount = 0;
+
 	@Nullable
 	public SchemaType getSchemaType() {
 		return this.schemaType;
@@ -75,6 +77,14 @@ public class PulsarProducerProperties extends ProducerConfigProperties {
 
 	public void setMessageValueType(@Nullable Class<?> messageValueType) {
 		this.messageValueType = messageValueType;
+	}
+
+	public int getPartitionCount() {
+		return this.partitionCount;
+	}
+
+	public void setPartitionCount(int partitionCount) {
+		this.partitionCount = partitionCount;
 	}
 
 }

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarProducerProperties.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarProducerProperties.java
@@ -41,7 +41,8 @@ public class PulsarProducerProperties extends ProducerConfigProperties {
 	@Nullable
 	private Class<?> messageValueType;
 
-	private int partitionCount = 0;
+	@Nullable
+	private Integer partitionCount;
 
 	@Nullable
 	public SchemaType getSchemaType() {
@@ -79,11 +80,12 @@ public class PulsarProducerProperties extends ProducerConfigProperties {
 		this.messageValueType = messageValueType;
 	}
 
-	public int getPartitionCount() {
+	@Nullable
+	public Integer getPartitionCount() {
 		return this.partitionCount;
 	}
 
-	public void setPartitionCount(int partitionCount) {
+	public void setPartitionCount(Integer partitionCount) {
 		this.partitionCount = partitionCount;
 	}
 

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/provisioning/PulsarTopicProvisioner.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/provisioning/PulsarTopicProvisioner.java
@@ -50,28 +50,26 @@ public class PulsarTopicProvisioner implements
 	public ProducerDestination provisionProducerDestination(String name,
 			ExtendedProducerProperties<PulsarProducerProperties> pulsarProducerProperties)
 			throws ProvisioningException {
-
-		int partitionCount = this.pulsarBinderConfigurationProperties.partitionCount();
-		int partitionCountOnBinding = pulsarProducerProperties.getPartitionCount();
-		if (partitionCountOnBinding > 1) {
-			partitionCount = partitionCountOnBinding;
-		}
-		PulsarTopic pulsarTopic = PulsarTopic.builder(name).numberOfPartitions(partitionCount).build();
+		int partitionCount = getPartitionCount(pulsarProducerProperties.getExtension().getPartitionCount());
+		var pulsarTopic = PulsarTopic.builder(name).numberOfPartitions(partitionCount).build();
 		this.pulsarAdministration.createOrModifyTopics(pulsarTopic);
 		return new PulsarDestination(pulsarTopic.topicName(), pulsarTopic.numberOfPartitions());
+	}
+
+	private int getPartitionCount(int partitionCountConfig) {
+		var partitionCount = this.pulsarBinderConfigurationProperties.partitionCount();
+		if (partitionCountConfig > 0) {
+			partitionCount = partitionCountConfig;
+		}
+		return partitionCount;
 	}
 
 	@Override
 	public ConsumerDestination provisionConsumerDestination(String name, String group,
 			ExtendedConsumerProperties<PulsarConsumerProperties> pulsarConsumerProperties)
 			throws ProvisioningException {
-		int partitionCount = this.pulsarBinderConfigurationProperties.partitionCount();
-
-		int partitionCountOnBinding = pulsarConsumerProperties.getExtension().getPartitionCount();
-		if (partitionCountOnBinding > 1) {
-			partitionCount = partitionCountOnBinding;
-		}
-		PulsarTopic pulsarTopic = PulsarTopic.builder(name).numberOfPartitions(partitionCount).build();
+		int partitionCount = getPartitionCount(pulsarConsumerProperties.getExtension().getPartitionCount());
+		var pulsarTopic = PulsarTopic.builder(name).numberOfPartitions(partitionCount).build();
 		this.pulsarAdministration.createOrModifyTopics(pulsarTopic);
 		return new PulsarDestination(pulsarTopic.topicName(), pulsarTopic.numberOfPartitions());
 	}

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/provisioning/PulsarTopicProvisioner.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/provisioning/PulsarTopicProvisioner.java
@@ -50,25 +50,27 @@ public class PulsarTopicProvisioner implements
 	public ProducerDestination provisionProducerDestination(String name,
 			ExtendedProducerProperties<PulsarProducerProperties> pulsarProducerProperties)
 			throws ProvisioningException {
-		int partitionCount = getPartitionCount(pulsarProducerProperties.getExtension().getPartitionCount());
+		Integer partitionCountFromBinding = pulsarProducerProperties.getExtension().getPartitionCount();
+		var partitionCount = getPartitionCount(partitionCountFromBinding);
 		var pulsarTopic = PulsarTopic.builder(name).numberOfPartitions(partitionCount).build();
 		this.pulsarAdministration.createOrModifyTopics(pulsarTopic);
 		return new PulsarDestination(pulsarTopic.topicName(), pulsarTopic.numberOfPartitions());
 	}
 
-	private int getPartitionCount(int partitionCountConfig) {
-		var partitionCount = this.pulsarBinderConfigurationProperties.partitionCount();
-		if (partitionCountConfig > 0) {
+	private int getPartitionCount(Integer partitionCountConfig) {
+		var partitionCount = this.pulsarBinderConfigurationProperties.getPartitionCount();
+		if (partitionCountConfig != null && partitionCountConfig > 0) {
 			partitionCount = partitionCountConfig;
 		}
-		return partitionCount;
+		return partitionCount == null ? 0 : partitionCount;
 	}
 
 	@Override
 	public ConsumerDestination provisionConsumerDestination(String name, String group,
 			ExtendedConsumerProperties<PulsarConsumerProperties> pulsarConsumerProperties)
 			throws ProvisioningException {
-		int partitionCount = getPartitionCount(pulsarConsumerProperties.getExtension().getPartitionCount());
+		var partitionCountFromBinding = pulsarConsumerProperties.getExtension().getPartitionCount();
+		var partitionCount = getPartitionCount(partitionCountFromBinding);
 		var pulsarTopic = PulsarTopic.builder(name).numberOfPartitions(partitionCount).build();
 		this.pulsarAdministration.createOrModifyTopics(pulsarTopic);
 		return new PulsarDestination(pulsarTopic.topicName(), pulsarTopic.numberOfPartitions());

--- a/spring-pulsar-spring-cloud-stream-binder/src/test/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarBinderConfigurationPropertiesTests.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/test/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarBinderConfigurationPropertiesTests.java
@@ -52,9 +52,9 @@ public class PulsarBinderConfigurationPropertiesTests {
 
 	@Test
 	void partitionCountProperty() {
-		assertThat(properties.partitionCount()).isEqualTo(0);
+		assertThat(properties.getPartitionCount()).isNull();
 		bind(Map.of("spring.cloud.stream.pulsar.binder.partition-count", "5150"));
-		assertThat(properties.partitionCount()).isEqualTo(5150);
+		assertThat(properties.getPartitionCount()).isEqualTo(5150);
 	}
 
 	@Test

--- a/spring-pulsar-spring-cloud-stream-binder/src/test/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarBinderConfigurationPropertiesTests.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/test/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarBinderConfigurationPropertiesTests.java
@@ -52,7 +52,7 @@ public class PulsarBinderConfigurationPropertiesTests {
 
 	@Test
 	void partitionCountProperty() {
-		assertThat(properties.partitionCount()).isEqualTo(1);
+		assertThat(properties.partitionCount()).isEqualTo(0);
 		bind(Map.of("spring.cloud.stream.pulsar.binder.partition-count", "5150"));
 		assertThat(properties.partitionCount()).isEqualTo(5150);
 	}

--- a/spring-pulsar-spring-cloud-stream-binder/src/test/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarTopicProvisionerTests.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/test/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarTopicProvisionerTests.java
@@ -50,7 +50,7 @@ public class PulsarTopicProvisionerTests {
 				new PulsarProducerProperties());
 		ProducerDestination producerDestination = pulsarTopicProvisioner.provisionProducerDestination("foo",
 				properties);
-		verifyAndAssert(pulsarAdministration, producerDestination.getName(), "foo", 1);
+		verifyAndAssert(pulsarAdministration, producerDestination.getName(), "foo", 0);
 	}
 
 	private static void verifyAndAssert(PulsarAdministration pulsarAdministration, String actualProducerDestination,
@@ -73,7 +73,7 @@ public class PulsarTopicProvisionerTests {
 				new PulsarConsumerProperties());
 		ConsumerDestination consumerDestination = pulsarTopicProvisioner.provisionConsumerDestination("bar", "",
 				properties);
-		verifyAndAssert(pulsarAdministration, consumerDestination.getName(), "bar", 1);
+		verifyAndAssert(pulsarAdministration, consumerDestination.getName(), "bar", 0);
 	}
 
 	@Test
@@ -98,7 +98,7 @@ public class PulsarTopicProvisionerTests {
 				pulsarBinderConfigurationProperties);
 		ExtendedProducerProperties<PulsarProducerProperties> properties = new ExtendedProducerProperties<>(
 				new PulsarProducerProperties());
-		properties.setPartitionCount(4);
+		properties.getExtension().setPartitionCount(4);
 		ProducerDestination producerDestination = pulsarTopicProvisioner.provisionProducerDestination("foo",
 				properties);
 		verifyAndAssert(pulsarAdministration, producerDestination.getName(), "foo", 4);


### PR DESCRIPTION
In Pulsar, partitioned topics are optional. If we set the default partition count to be 1, then it unnecessarily creates a partitoned topic. Therefore, we need to set the default partition count as 0 in the binder and extended binding properties.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
