### PR TITLE
[Docs] Move topic resolution out of appendix

### DIFF
--- a/spring-pulsar-docs/src/main/asciidoc/index.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/index.adoc
@@ -44,8 +44,6 @@ In addition to this reference documentation, we recommend a number of other reso
 
 include::application-properties.adoc[leveloffset=+2]
 
-include::topic-resolution.adoc[leveloffset=+2]
-
 include::non-ga-versions.adoc[leveloffset=+2]
 
 include::native-image.adoc[leveloffset=+2]

--- a/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/pulsar.adoc
@@ -34,7 +34,7 @@ They return the `MessageId` of the message that was published once the message i
 The `sendAsync` method calls are asynchronous calls that are non-blocking.
 They return a `CompletableFuture`, which you can use to asynchronously receive the message ID once the messages are published.
 
-NOTE: For the API variants that do not include a topic parameter, a <<topic-resolution.adoc#appendix.topic-resolution,topic resolution process>> is used to determine the destination topic.
+NOTE: For the API variants that do not include a topic parameter, a <<topic-resolution-process-imperative,topic resolution process>> is used to determine the destination topic.
 
 ==== Simple API
 The template provides a handful of methods ({javadocs}/org/springframework/pulsar/core/PulsarOperations.html[prefixed with _'send'_]) for simple send requests. For more complicated send requests, a fluent API lets you configure more options.
@@ -99,7 +99,7 @@ include::schema-info/schema-info-template.adoc[leveloffset=+1]
 The `PulsarTemplate` relies on a `PulsarProducerFactory` to actually create the underlying producer. Spring Boot auto-configuration also provides this producer factory. Additionally, you can configure the factory by specifying any of the available producer-centric application properties.
 See the <<application-properties.adoc#appendix.application-properties.pulsar-producer,Appendix>>.
 
-NOTE: If topic information is not specified when using the producer factory APIs directly, the same <<topic-resolution.adoc#appendix.topic-resolution,topic resolution process>> used by the `PulsarTemplate` is used with the one exception that the "Message type default" step is **omitted**.
+NOTE: If topic information is not specified when using the producer factory APIs directly, the same <<topic-resolution-process-imperative,topic resolution process>> used by the `PulsarTemplate` is used with the one exception that the "Message type default" step is **omitted**.
 
 [[producer-caching]]
 ==== Pulsar Producer Caching
@@ -180,7 +180,7 @@ spring.pulsar.consumer:
   subscription-name: hello-pulsar-subscription
 ----
 
-NOTE: If the topic information is not directly provided, a <<topic-resolution.adoc#appendix.topic-resolution,topic resolution process>> is used to determine the destination topic.
+NOTE: If the topic information is not directly provided, a <<topic-resolution-process-imperative,topic resolution process>> is used to determine the destination topic.
 
 
 In the `PulsarListener` method shown earlier, we receive the data as `String`, but we do not specify any schema types.
@@ -420,7 +420,7 @@ return pulsarListenerContainer;
 ----
 ====
 
-NOTE: If topic information is not specified when using the listener containers directly, the same <<topic-resolution.adoc#appendix.topic-resolution,topic resolution process>> used by the `PulsarListener` is used with the one exception that the "Message type default" step is **omitted**.
+NOTE: If topic information is not specified when using the listener containers directly, the same <<topic-resolution-process-imperative,topic resolution process>> used by the `PulsarListener` is used with the one exception that the "Message type default" step is **omitted**.
 
 `DefaultPulsarMessageListenerContainer` creates only a single consumer.
 If you want to have multiple consumers managed through multiple threads, you need to use `ConcurrentPulsarMessageListenerContainer`.
@@ -1176,7 +1176,9 @@ The framework provides support for using {apache-pulsar-docs}/concepts-clients/#
 
 Spring Boot provides this reader factory which can be configured with any of the <<application-properties.adoc#appendix.application-properties.pulsar-reader,`spring.pulsar.reader`>> prefixed application properties.
 
-
+[[topic-resolution-process-imperative]]
+== Topic Resolution
+include::topic-resolution.adoc[leveloffset=+1]
 
 == Publishing and Consuming Partitioned Topics
 

--- a/spring-pulsar-docs/src/main/asciidoc/reactive-pulsar.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/reactive-pulsar.adoc
@@ -61,7 +61,7 @@ On the Pulsar producer side, Spring Boot auto-configuration provides a `Reactive
 The template provides send methods that accept a single message and return a `Mono<MessageId>`.
 It also provides send methods that accept multiple messages (in the form of the ReactiveStreams `Publisher` type) and return a `Flux<MessageId>`.
 
-NOTE: For the API variants that do not include a topic parameter, a <<topic-resolution.adoc#appendix.topic-resolution,topic resolution process>> is used to determine the destination topic.
+NOTE: For the API variants that do not include a topic parameter, a <<topic-resolution-process-reactive,topic resolution process>> is used to determine the destination topic.
 
 ==== Fluent API
 The template provides a {javadocs}/org/springframework/pulsar/reactive/core/ReactivePulsarOperations.html#newMessage(T)[fluent builder] to handle more complicated send requests.
@@ -114,7 +114,7 @@ The `ReactivePulsarTemplate` relies on a `ReactivePulsarSenderFactory` to actual
 
 Spring Boot provides this sender factory which can be configured with any of the <<application-properties.adoc#appendix.application-properties.pulsar-reactive-sender,`spring.pulsar.reactive.sender`>> prefixed application properties.
 
-NOTE: If topic information is not specified when using the sender factory APIs directly, the same <<topic-resolution.adoc#appendix.topic-resolution,topic resolution process>> used by the `ReactivePulsarTemplate` is used with the one exception that the "Message type default" step is **omitted**.
+NOTE: If topic information is not specified when using the sender factory APIs directly, the same <<topic-resolution-process-reactive,topic resolution process>> used by the `ReactivePulsarTemplate` is used with the one exception that the "Message type default" step is **omitted**.
 
 ==== Producer Caching
 Each underlying Pulsar producer consumes resources.
@@ -170,7 +170,7 @@ spring.pulsar.reactive.consumer:
 
 When `subscription-name` is not provided an auto-generated subscription name will be used.
 
-NOTE: If the topic information is not directly provided, a <<topic-resolution.adoc#appendix.topic-resolution,topic resolution process>> is used to determine the destination topic.
+NOTE: If the topic information is not directly provided, a <<topic-resolution-process-reactive,topic resolution process>> is used to determine the destination topic.
 
 
 In the `ReactivePulsarListener` method shown earlier, we receive the data as `String`, but we do not specify any schema types.
@@ -329,7 +329,7 @@ The "listener" aspect is provided by the `ReactivePulsarMessageHandler` of which
 * `ReactivePulsarOneByOneMessageHandler` - handles a single message one-by-one
 * `ReactivePulsarStreamingHandler` - handles multiple messages via a `Flux`
 
-NOTE: If topic information is not specified when using the listener containers directly, the same <<topic-resolution.adoc#appendix.topic-resolution,topic resolution process>> used by the `ReactivePulsarListener` is used with the one exception that the "Message type default" step is **omitted**.
+NOTE: If topic information is not specified when using the listener containers directly, the same <<topic-resolution-process-reactive,topic resolution process>> used by the `ReactivePulsarListener` is used with the one exception that the "Message type default" step is **omitted**.
 
 [[reactive-concurrency]]
 === Concurrency
@@ -499,3 +499,7 @@ The easy way to solve this is to provide a DLQ topic name always.
 The framework provides support for using {apache-pulsar-docs}/concepts-clients/#reader-interface[Pulsar Reader] in a Reactive fashion via the `ReactivePulsarReaderFactory`.
 
 Spring Boot provides this reader factory which can be configured with any of the <<application-properties.adoc#appendix.application-properties.pulsar-reactive-reader,`spring.pulsar.reactive.reader`>> prefixed application properties.
+
+[[topic-resolution-process-reactive]]
+== Topic Resolution
+include::topic-resolution.adoc[leveloffset=+1]

--- a/spring-pulsar-docs/src/main/asciidoc/topic-resolution.adoc
+++ b/spring-pulsar-docs/src/main/asciidoc/topic-resolution.adoc
@@ -1,7 +1,3 @@
-[appendix]
-[[appendix.topic-resolution]]
-= Topic Resolution
-
 A destination topic is needed when producing or consuming messages.
 The framework looks in the following ordered locations to determine a topic (stopping at the first find):
 


### PR DESCRIPTION
Moves the topic resolution from the appendix into an included section in the imperative and reactive pages. 
Each link to the topic resolution in the imperative section links to its included topic resolution section. 
Each link to the topic resolution in the reactive section links to its included topic resolution section.