### PR TITLE
Add bindings props to generated docs

### DIFF
--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarBinderConfigurationProperties.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarBinderConfigurationProperties.java
@@ -23,7 +23,9 @@ import org.springframework.pulsar.autoconfigure.ConsumerConfigProperties;
 import org.springframework.pulsar.autoconfigure.ProducerConfigProperties;
 
 /**
- * {@link ConfigurationProperties} for Pulsar binder configuration.
+ * {@link ConfigurationProperties @ConfigurationProperties} for the Pulsar binder.
+ * <p>
+ * These properties are applied at the binder level (to all bindings).
  *
  * @author Soby Chacko
  * @author Chris Bono
@@ -31,9 +33,15 @@ import org.springframework.pulsar.autoconfigure.ProducerConfigProperties;
 @ConfigurationProperties(prefix = "spring.cloud.stream.pulsar.binder")
 public class PulsarBinderConfigurationProperties {
 
+	/**
+	 * Pulsar consumer specific binder-level properties (applied to all bindings).
+	 */
 	@NestedConfigurationProperty
 	private final ConsumerConfigProperties consumer = new ConsumerConfigProperties();
 
+	/**
+	 * Pulsar producer specific binder-level properties (applied to all bindings).
+	 */
 	@NestedConfigurationProperty
 	private final ProducerConfigProperties producer = new ProducerConfigProperties();
 

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarBindingProperties.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarBindingProperties.java
@@ -16,12 +16,40 @@
 
 package org.springframework.pulsar.spring.cloud.stream.binder.properties;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
 
+/**
+ * Container for Pulsar specific extended producer and consumer binding properties.
+ * <p>
+ * These properties are applied to individual bindings and will override any binder-level
+ * setting.
+ *
+ * <p>
+ * <em>NOTE:</em> This class is only referenced as a value in the
+ * {@link PulsarExtendedBindingProperties#getBindings() bindings map} and therefore, by
+ * default is not included in the generated configuration metadata. To get around this
+ * limitation it is annotated with {@code @ConfigurationProperties}. However, that is the
+ * only reason it is annotated and is not intended to be used directly.
+ *
+ * @author Soby Chacko
+ * @author Chris Bono
+ */
+@SuppressWarnings("ConfigurationProperties")
+@ConfigurationProperties("spring.cloud.stream.pulsar.bindings.for-docs-only")
 public class PulsarBindingProperties implements BinderSpecificPropertiesProvider {
 
+	/**
+	 * Pulsar consumer specific binding properties.
+	 */
+	@NestedConfigurationProperty
 	private PulsarConsumerProperties consumer = new PulsarConsumerProperties();
 
+	/**
+	 * Pulsar producer specific binding properties.
+	 */
+	@NestedConfigurationProperty
 	private PulsarProducerProperties producer = new PulsarProducerProperties();
 
 	public PulsarConsumerProperties getConsumer() {

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarExtendedBindingProperties.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/properties/PulsarExtendedBindingProperties.java
@@ -22,6 +22,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.cloud.stream.binder.AbstractExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.BinderSpecificPropertiesProvider;
 
+/**
+ * {@link ConfigurationProperties @ConfigurationProperties} for Pulsar binder specific
+ * extensions to the common binding properties.
+ * <p>
+ * These properties are applied to individual bindings and will override any binder-level
+ * settings.
+ *
+ * @author Soby Chacko
+ * @author Chris Bono
+ */
 @ConfigurationProperties("spring.cloud.stream.pulsar")
 public class PulsarExtendedBindingProperties extends
 		AbstractExtendedBindingProperties<PulsarConsumerProperties, PulsarProducerProperties, PulsarBindingProperties> {
@@ -33,6 +43,9 @@ public class PulsarExtendedBindingProperties extends
 		return DEFAULTS_PREFIX;
 	}
 
+	/**
+	 * Properties per individual binding name (e.g. 'mySink-in-0').
+	 */
 	@Override
 	public Map<String, PulsarBindingProperties> getBindings() {
 		return this.doGetBindings();

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "groups": [],
+  "properties": [
+    {
+      "name": "spring.cloud.stream.pulsar.bindings",
+      "description": "Properties per individual binding name (e.g. 'mySink-in-0'). Replace the '*' ' with the name of your binding."
+    }
+  ],
+  "hints": []
+}


### PR DESCRIPTION
Extend the base config props doc generation to expand config props in maps.


<img width="1023" alt="Screen Shot 2023-02-26 at 12 18 04" src="https://user-images.githubusercontent.com/28907971/221428920-755910e8-1b2a-4bf6-929c-b33182b767dd.png">
