### PR TITLE
Add SCSt binder specific header mapper

### DIFF
--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarBinderHeaderMapper.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarBinderHeaderMapper.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.spring.cloud.stream.binder;
+
+import java.util.Map;
+
+import org.apache.pulsar.client.api.Message;
+
+import org.springframework.cloud.stream.binder.BinderHeaders;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.pulsar.support.header.PulsarHeaderMapper;
+
+/**
+ * A delegating {@code PulsarHeaderMapper} that ensures the delegate mapper never includes
+ * internal binder specific headers during outbound mapping.
+ *
+ * @author Chris Bono
+ */
+class PulsarBinderHeaderMapper implements PulsarHeaderMapper {
+
+	private final PulsarHeaderMapper delegate;
+
+	/**
+	 * Construct a mapper with the specified delegate.
+	 * @param delegate the delegate mapper
+	 */
+	PulsarBinderHeaderMapper(PulsarHeaderMapper delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public Map<String, String> toPulsarHeaders(MessageHeaders springHeaders) {
+		Map<String, String> pulsarHeaders = this.delegate.toPulsarHeaders(springHeaders);
+		pulsarHeaders.remove(MessageHeaders.ID);
+		pulsarHeaders.remove(MessageHeaders.TIMESTAMP);
+		pulsarHeaders.remove(IntegrationMessageHeaderAccessor.DELIVERY_ATTEMPT);
+		pulsarHeaders.remove(BinderHeaders.NATIVE_HEADERS_PRESENT);
+		return pulsarHeaders;
+	}
+
+	@Override
+	public MessageHeaders toSpringHeaders(Message<?> pulsarMessage) {
+		var springHeaders = this.delegate.toSpringHeaders(pulsarMessage);
+		if (!springHeaders.isEmpty()) {
+			MessageHeaderAccessor mutableHeaders = new MessageHeaderAccessor();
+			mutableHeaders.copyHeaders(springHeaders);
+			mutableHeaders.setHeader(BinderHeaders.NATIVE_HEADERS_PRESENT, Boolean.TRUE);
+			springHeaders = mutableHeaders.getMessageHeaders();
+		}
+		return springHeaders;
+	}
+
+}

--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/config/PulsarBinderConfiguration.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/config/PulsarBinderConfiguration.java
@@ -30,8 +30,10 @@ import org.springframework.pulsar.spring.cloud.stream.binder.PulsarMessageChanne
 import org.springframework.pulsar.spring.cloud.stream.binder.properties.PulsarBinderConfigurationProperties;
 import org.springframework.pulsar.spring.cloud.stream.binder.properties.PulsarExtendedBindingProperties;
 import org.springframework.pulsar.spring.cloud.stream.binder.provisioning.PulsarTopicProvisioner;
+import org.springframework.pulsar.support.header.JacksonUtils;
 import org.springframework.pulsar.support.header.JsonPulsarHeaderMapper;
 import org.springframework.pulsar.support.header.PulsarHeaderMapper;
+import org.springframework.pulsar.support.header.ToStringPulsarHeaderMapper;
 
 /**
  * Pulsar binder {@link Configuration}.
@@ -51,8 +53,12 @@ public class PulsarBinderConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	public PulsarHeaderMapper pulsarHeaderMapper() {
-		return JsonPulsarHeaderMapper.builder().build();
+		if (JacksonUtils.isJacksonPresent()) {
+			return JsonPulsarHeaderMapper.builder().build();
+		}
+		return new ToStringPulsarHeaderMapper();
 	}
 
 	@Bean

--- a/spring-pulsar-spring-cloud-stream-binder/src/test/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarBinderHeaderMapperTests.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/test/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarBinderHeaderMapperTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.pulsar.spring.cloud.stream.binder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.pulsar.client.api.Message;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.cloud.stream.binder.BinderHeaders;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.pulsar.support.header.PulsarHeaderMapper;
+
+/**
+ * Tests for {@link PulsarBinderHeaderMapper}.
+ *
+ * @author Chris Bono
+ */
+@ExtendWith(MockitoExtension.class)
+class PulsarBinderHeaderMapperTests {
+
+	@Mock
+	private PulsarHeaderMapper delegateMapper;
+
+	@InjectMocks
+	private PulsarBinderHeaderMapper binderHeaderMapper;
+
+	@Nested
+	class ToPulsarHeadersOutboundTests {
+
+		@Test
+		void delegateReturnsEmptyHeaders() {
+			var delegatePulsarHeaders = new HashMap<String, String>();
+			when(delegateMapper.toPulsarHeaders(any(MessageHeaders.class))).thenReturn(delegatePulsarHeaders);
+			var springHeaders = mock(MessageHeaders.class);
+			var pulsarHeaders = binderHeaderMapper.toPulsarHeaders(springHeaders);
+			verify(delegateMapper).toPulsarHeaders(springHeaders);
+			assertThat(pulsarHeaders).isEmpty();
+		}
+
+		@Test
+		void neverHeadersRemovedFromDelegateHeaders() {
+			var delegatePulsarHeaders = new HashMap<String, String>();
+			delegatePulsarHeaders.put(MessageHeaders.ID, "5150");
+			delegatePulsarHeaders.put(MessageHeaders.TIMESTAMP, "12345");
+			delegatePulsarHeaders.put(IntegrationMessageHeaderAccessor.DELIVERY_ATTEMPT, "5");
+			delegatePulsarHeaders.put(BinderHeaders.NATIVE_HEADERS_PRESENT, "true");
+			delegatePulsarHeaders.put("foo", "bar");
+			when(delegateMapper.toPulsarHeaders(any(MessageHeaders.class))).thenReturn(delegatePulsarHeaders);
+			var springHeaders = mock(MessageHeaders.class);
+			var pulsarHeaders = binderHeaderMapper.toPulsarHeaders(springHeaders);
+			verify(delegateMapper).toPulsarHeaders(springHeaders);
+			assertThat(pulsarHeaders).containsOnly(entry("foo", "bar"));
+		}
+
+	}
+
+	@Nested
+	class ToSpringHeadersInboundTests {
+
+		@Test
+		void delegateReturnsEmptyHeaders() {
+			var emptyDelegateHeaders = mock(MessageHeaders.class);
+			when(emptyDelegateHeaders.isEmpty()).thenReturn(true);
+			when(delegateMapper.toSpringHeaders(any(Message.class))).thenReturn(emptyDelegateHeaders);
+			var springHeaders = binderHeaderMapper.toSpringHeaders(mock(Message.class));
+			assertThat(springHeaders).isSameAs(emptyDelegateHeaders);
+			verify(springHeaders).isEmpty();
+			verifyNoMoreInteractions(springHeaders);
+		}
+
+		@Test
+		void nativeHeadersIndicatorAddedToDelegateHeaders() {
+			var delegateSpringHeaders = new MessageHeaders(Map.of("foo", "bar"));
+			when(delegateMapper.toSpringHeaders(any(Message.class))).thenReturn(delegateSpringHeaders);
+			var pulsarMessage = mock(Message.class);
+			var springHeaders = binderHeaderMapper.toSpringHeaders(pulsarMessage);
+			verify(delegateMapper).toSpringHeaders(pulsarMessage);
+			assertThat(springHeaders).containsEntry("foo", "bar").containsEntry(BinderHeaders.NATIVE_HEADERS_PRESENT,
+					Boolean.TRUE);
+
+		}
+
+	}
+
+}

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/support/header/AbstractPulsarHeaderMapper.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/support/header/AbstractPulsarHeaderMapper.java
@@ -51,6 +51,10 @@ import org.springframework.pulsar.support.header.PulsarHeaderMatcher.PatternMatc
 public abstract class AbstractPulsarHeaderMapper<ToPulsarHeadersContextType, ToSpringHeadersContextType>
 		implements PulsarHeaderMapper {
 
+	private static final PatternMatch EXCLUDE_PATTERN_ID = PatternMatch.fromPatternString("!id");
+
+	private static final PatternMatch EXCLUDE_PATTERN_TIMESTAMP = PatternMatch.fromPatternString("!timestamp");
+
 	protected final LogAccessor logger = new LogAccessor(this.getClass());
 
 	private final List<PulsarHeaderMatcher> inboundMatchers = new ArrayList<>();
@@ -99,14 +103,14 @@ public abstract class AbstractPulsarHeaderMapper<ToPulsarHeadersContextType, ToS
 				PulsarHeaders.TOPIC_NAME));
 		// @formatter:on
 		if (outboundPatterns.isEmpty()) {
-			this.outboundMatchers.add(PatternMatch.fromPatternString("!id"));
-			this.outboundMatchers.add(PatternMatch.fromPatternString("!timestamp"));
+			this.outboundMatchers.add(EXCLUDE_PATTERN_ID);
+			this.outboundMatchers.add(EXCLUDE_PATTERN_TIMESTAMP);
 			this.outboundMatchers.add(PatternMatch.fromPatternString("*"));
 		}
 		else {
 			outboundPatterns.forEach((p) -> this.outboundMatchers.add(PatternMatch.fromPatternString(p)));
-			this.outboundMatchers.add(PatternMatch.fromPatternString("!id"));
-			this.outboundMatchers.add(PatternMatch.fromPatternString("!timestamp"));
+			this.outboundMatchers.add(EXCLUDE_PATTERN_ID);
+			this.outboundMatchers.add(EXCLUDE_PATTERN_TIMESTAMP);
 		}
 	}
 

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/support/header/JacksonUtils.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/support/header/JacksonUtils.java
@@ -31,6 +31,11 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
  */
 public final class JacksonUtils {
 
+	private static final ClassLoader classLoader = ClassUtils.getDefaultClassLoader();
+
+	private static final boolean JACKSON_PRESENT = ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper",
+			classLoader) && ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", classLoader);
+
 	private static final boolean JDK8_MODULE_PRESENT = ClassUtils
 			.isPresent("com.fasterxml.jackson.datatype.jdk8.Jdk8Module", null);
 
@@ -39,6 +44,14 @@ public final class JacksonUtils {
 
 	private static final boolean JODA_MODULE_PRESENT = ClassUtils
 			.isPresent("com.fasterxml.jackson.datatype.joda.JodaModule", null);
+
+	/**
+	 * Determines if the Jackson JSON processor is on the classpath.
+	 * @return whether Jackson JSON processor is available on the classpath
+	 */
+	public static boolean isJacksonPresent() {
+		return JACKSON_PRESENT;
+	}
 
 	/**
 	 * Factory for {@link ObjectMapper} instances with registered well-known modules and

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/support/header/package-info.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/support/header/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Package containing components to support Pulsar header functionality.
+ */
+@NonNullApi
+@NonNullFields
+package org.springframework.pulsar.support.header;
+
+import org.springframework.lang.NonNullApi;
+import org.springframework.lang.NonNullFields;


### PR DESCRIPTION
Add SCSt Pulsar binder specific header mapper that wraps the auto-configured header mapper and removes NEVER binder-specific headers. 

Adds IT tests for the binder complex headers etc..

See #366

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
