### PR TITLE
Dependency hygiene required by Spring Boot

### DIFF
--- a/spring-pulsar-reactive/build.gradle
+++ b/spring-pulsar-reactive/build.gradle
@@ -6,15 +6,23 @@ description = 'Spring Pulsar Reactive Support'
 
 dependencies {
 	api project (':spring-pulsar')
-	api 'org.apache.pulsar:pulsar-client-reactive-adapter'
+	api ('org.apache.pulsar:pulsar-client-reactive-adapter') {
+		// remove when reactive client updates to 2.11
+		exclude group: 'org.apache.pulsar', module: 'pulsar-client'
+	}
 	implementation 'com.fasterxml.jackson.core:jackson-core'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'com.google.code.findbugs:jsr305'
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-joda'
+	optional 'com.google.protobuf:protobuf-java'
 	optional 'com.jayway.jsonpath:json-path'
 	optional 'io.projectreactor:reactor-core'
+	optional ('org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine') {
+		// remove when reactive client updates to 2.11
+		exclude group: 'org.apache.pulsar', module: 'pulsar-client-reactive-adapter'
+	}
 
 	testImplementation project(':spring-pulsar-test')
 	testRuntimeOnly 'ch.qos.logback:logback-classic'

--- a/spring-pulsar-spring-boot-autoconfigure/build.gradle
+++ b/spring-pulsar-spring-boot-autoconfigure/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
 	optional project (':spring-pulsar')
 	optional project (':spring-pulsar-reactive')
+	optional 'com.github.ben-manes.caffeine:caffeine'
 	optional 'org.apache.pulsar:pulsar-client-reactive-producer-cache-caffeine'
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'com.google.code.findbugs:jsr305'

--- a/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
+++ b/spring-pulsar-spring-boot-autoconfigure/src/main/java/org/springframework/pulsar/autoconfigure/PulsarAutoConfiguration.java
@@ -51,6 +51,7 @@ import org.springframework.pulsar.function.PulsarSink;
 import org.springframework.pulsar.function.PulsarSource;
 import org.springframework.pulsar.observation.PulsarTemplateObservationConvention;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.micrometer.observation.ObservationRegistry;
 
 /**
@@ -88,6 +89,7 @@ public class PulsarAutoConfiguration {
 
 	@Bean
 	@ConditionalOnMissingBean
+	@ConditionalOnClass(Caffeine.class)
 	@ConditionalOnProperty(name = "spring.pulsar.producer.cache.enabled", havingValue = "true", matchIfMissing = true)
 	public PulsarProducerFactory<?> cachingPulsarProducerFactory(PulsarClient pulsarClient,
 			TopicResolver topicResolver) {

--- a/spring-pulsar-spring-boot-starter/build.gradle
+++ b/spring-pulsar-spring-boot-starter/build.gradle
@@ -7,5 +7,6 @@ description = 'Spring Pulsar Spring Boot Starter'
 dependencies {
 	api project (':spring-pulsar')
 	api project (':spring-pulsar-spring-boot-autoconfigure')
+	api 'com.github.ben-manes.caffeine:caffeine'
 	api 'org.springframework.boot:spring-boot-starter'
 }

--- a/spring-pulsar/build.gradle
+++ b/spring-pulsar/build.gradle
@@ -5,11 +5,11 @@ plugins {
 description = 'Spring Pulsar Support'
 
 dependencies {
-	api 'com.github.ben-manes.caffeine:caffeine'
-	api 'com.google.protobuf:protobuf-java'
 	api 'io.micrometer:micrometer-observation'
 	api ('org.apache.pulsar:pulsar-client-all') {
 		exclude group: 'org.apache.logging.log4j'
+		exclude group: 'com.sun.activation', module: 'javax.activation'
+		exclude group: 'javax.validation', module: 'validation-api'
 	}
 	api 'org.springframework:spring-context'
 	api 'org.springframework:spring-messaging'
@@ -23,6 +23,8 @@ dependencies {
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 	optional 'com.fasterxml.jackson.datatype:jackson-datatype-joda'
+	optional 'com.github.ben-manes.caffeine:caffeine'
+	optional 'com.google.protobuf:protobuf-java'
 	optional 'com.jayway.jsonpath:json-path'
 
 	testImplementation project(':spring-pulsar-test')

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultSchemaResolver.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/core/DefaultSchemaResolver.java
@@ -42,8 +42,6 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
 
-import com.google.protobuf.GeneratedMessageV3;
-
 /**
  * Default schema resolver capable of handling basic message types.
  *
@@ -178,8 +176,10 @@ public class DefaultSchemaResolver implements SchemaResolver {
 				case JSON -> JSONSchema.of(requireNonNullMessageType(schemaType, messageType));
 				case AVRO -> AvroSchema.of(requireNonNullMessageType(schemaType, messageType));
 				case PROTOBUF -> {
+					// WARN! Leave GeneratedMessageV3 fully-qualified as the dependency is
+					// optional
 					Class<?> messageClass = requireNonNullMessageType(schemaType, messageType);
-					yield ProtobufSchema.of((Class<? extends GeneratedMessageV3>) messageClass);
+					yield ProtobufSchema.of((Class<? extends com.google.protobuf.GeneratedMessageV3>) messageClass);
 				}
 				case KEY_VALUE -> {
 					requireNonNullMessageType(schemaType, messageType);


### PR DESCRIPTION
Tightens up some dependencies so that when we move into Spring Boot we do not bring unwanted transitive dependencies etc..