### PR TITLE
Better container properties sync

### DIFF
--- a/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarMessageChannelBinder.java
+++ b/spring-pulsar-spring-cloud-stream-binder/src/main/java/org/springframework/pulsar/spring/cloud/stream/binder/PulsarMessageChannelBinder.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
-import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.common.schema.SchemaType;
 
 import org.springframework.cloud.stream.binder.AbstractMessageChannelBinder;
@@ -163,9 +162,6 @@ public class PulsarMessageChannelBinder extends
 		}
 		var subscriptionName = PulsarBinderUtils.subscriptionName(properties.getExtension(), destination);
 		containerProperties.setSubscriptionName(subscriptionName);
-		if (properties.getExtension().getSubscriptionType() != SubscriptionType.Exclusive) {
-			containerProperties.setSubscriptionType(properties.getExtension().getSubscriptionType());
-		}
 
 		var baseConsumerProps = new ConsumerConfigProperties().buildProperties();
 		var binderConsumerProps = this.binderConfigProps.getConsumer().buildProperties();
@@ -173,6 +169,7 @@ public class PulsarMessageChannelBinder extends
 		var mergedConsumerProps = PulsarBinderUtils.mergePropertiesWithPrecedence(baseConsumerProps,
 				binderConsumerProps, bindingConsumerProps);
 		containerProperties.getPulsarConsumerProperties().putAll(mergedConsumerProps);
+		containerProperties.updateContainerProperties();
 
 		var container = new DefaultPulsarMessageListenerContainer<>(this.pulsarConsumerFactory, containerProperties);
 		messageDrivenChannelAdapter.setMessageListenerContainer(container);

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/config/AbstractPulsarListenerContainerFactory.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/config/AbstractPulsarListenerContainerFactory.java
@@ -178,6 +178,8 @@ public abstract class AbstractPulsarListenerContainerFactory<C extends AbstractP
 				.acceptIfNotNull(this.applicationEventPublisher, instance::setApplicationEventPublisher)
 				.acceptIfNotNull(endpoint.getConsumerProperties(),
 						instance.getContainerProperties()::setPulsarConsumerProperties);
+		// Update container properties if there are relevant direct consumer properties
+		instanceProperties.updateContainerProperties();
 	}
 
 }

--- a/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
+++ b/spring-pulsar/src/main/java/org/springframework/pulsar/listener/PulsarContainerProperties.java
@@ -42,6 +42,10 @@ public class PulsarContainerProperties {
 
 	private static final Duration DEFAULT_CONSUMER_START_TIMEOUT = Duration.ofSeconds(30);
 
+	private static final String SUBSCRIPTION_NAME = "subscriptionName";
+
+	private static final String SUBSCRIPTION_TYPE = "subscriptionType";
+
 	private Duration consumerStartTimeout = DEFAULT_CONSUMER_START_TIMEOUT;
 
 	private String[] topics;
@@ -244,6 +248,17 @@ public class PulsarContainerProperties {
 
 	public void setPulsarConsumerProperties(Properties pulsarConsumerProperties) {
 		this.pulsarConsumerProperties = pulsarConsumerProperties;
+	}
+
+	public void updateContainerProperties() {
+		if (!this.pulsarConsumerProperties.isEmpty()) {
+			if (this.pulsarConsumerProperties.containsKey(SUBSCRIPTION_NAME)) {
+				this.subscriptionName = (String) this.pulsarConsumerProperties.get(SUBSCRIPTION_NAME);
+			}
+			if (this.pulsarConsumerProperties.containsKey(SUBSCRIPTION_TYPE)) {
+				this.subscriptionType = (SubscriptionType) this.pulsarConsumerProperties.get(SUBSCRIPTION_TYPE);
+			}
+		}
 	}
 
 }


### PR DESCRIPTION
 * If consumer properties are directly overridden, we need to sync that with container properties. This commit tries to centralize this synching.

<!--
Thanks for contributing to Spring for Apache Pulsar. Please review the following notes before
submitting a pull request.

Please submit only genuine pull-requests. Do not use this repository as a GitHub
playground.

Security Vulnerabilities

STOP! If your contribution fixes a security vulnerability, please do not submit it.
Instead, please head over to https://spring.io/security-policy to learn how to disclose a
vulnerability responsibly.

Dependency Upgrades

Please do not open a pull request for a dependency upgrade. The team prefers to handles these internally. However, if a fix or feature requires an upgrade of a library go ahead and submit the upgrade with the code proposal and the review process will determine if it is accepted. 

CI / Build Changes

Please do not open a pull request for a CI or build changes. The team prefers to handles these internally. Instead, open an issue to report any problems or improvements in this area.


Describing Your Changes

If, having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
